### PR TITLE
Re-design Tekton Resource Pruner to delete only Pods and PVCs

### DIFF
--- a/charts/pipelines-library/scripts/tekton-prune.sh
+++ b/charts/pipelines-library/scripts/tekton-prune.sh
@@ -1,0 +1,121 @@
+#!/usr/bin/env bash
+
+set -o errtrace
+trap 'echo "error occurred on line ${LINENO}"; exit 1' ERR
+
+verify() {
+  echo 'Verify that kubectl is installed'
+  if ! command -v kubectl &> /dev/null; then
+    echo "kubectl could not be found"
+    exit 1
+  fi
+  echo 'Ok'
+  echo 'Verify that required environment variables are defined'
+  if test -z "${NAMESPACE}"; then
+    echo 'NAMESPACE env variable not defined.'
+    exit 1
+  fi
+  if test -z "${RECENT_MINUTES}"; then
+    echo 'RECENT_MINUTES env variable not defined.'
+    exit 1
+  fi
+  echo 'Ok'
+}
+
+get_pipelinerun_pods_to_file() {
+  pods_file_path="$1"
+  kubectl get -n "${NAMESPACE}" pod -l tekton.dev/memberOf -o name > "${pods_file_path}"
+}
+
+get_pipelinerun_pvcs_to_file() {
+  pvcs_file_path="$1"
+  separator="$2"
+  owner="$3"
+  kubectl get -n "${NAMESPACE}" -o json $(kubectl get -n "${NAMESPACE}" pvc -o name) \
+    | jq -r --arg separator "${separator}" --arg owner "${owner}" '.items[]
+    | select(.metadata.ownerReferences[0].kind? == "\($owner)")
+    | "\(.metadata.name)\($separator)\(.metadata.ownerReferences[0].name)"' > "${pvcs_file_path}"
+}
+
+get_active_pipelineruns() {
+  kubectl get -n "${NAMESPACE}" pipelineruns \
+    -o jsonpath='{.items[?(@.status.conditions[0].reason=="Running")].metadata.name}'
+}
+
+get_recent_pipelineruns() {
+  minutes="$1"
+  date_minus_minutes_iso8601=$(TZ=UTC date -u +"%FT%TZ" --date "-${minutes} min")
+  kubectl get pipelineruns -n "${NAMESPACE}" -o json \
+    | jq -r --arg d "${date_minus_minutes_iso8601}" \
+      '.items[] | select (.status.completionTime? > $d ) | .metadata.name'
+}
+
+delete_lines_from_file() {
+  file="$1"
+  lines_to_delete="$2"
+  for line in ${lines_to_delete[@]}; do
+    sed -i "/${line}/d" "${file}"
+  done
+}
+
+prune_resources() {
+  resources_to_delete_file_path="$1"
+  type="$2"
+  resource_list=''
+  while IFS= read -r line || [[ -n "${line}" ]]; do
+    if ! test -z "${line}"; then resource_list="${resource_list} ${type}${line}"; fi
+  done < "$resources_to_delete_file_path"
+  if test -z "${resource_list// }"; then
+    echo 'No resources to delete'
+  else
+    kubectl delete -n "${NAMESPACE}" ${resource_list} --force --grace-period=0;
+  fi
+}
+
+main() {
+  separator=';'
+  pvc_owner_kind='PipelineRun'
+  pods_to_delete_file_path='/tmp/pods-to-delete.txt'
+  pvcs_to_delete_file_path='/tmp/PVCs-to-delete.txt'
+
+  verify
+
+  echo 'Get active pipelineruns'
+  active_pipelineruns=$(get_active_pipelineruns)
+  echo "active pipelineruns: $active_pipelineruns"
+
+  echo "Get pipelineruns completed recently (in the last ${RECENT_MINUTES} minutes)"
+  recent_pipelineruns=$(get_recent_pipelineruns "${RECENT_MINUTES}")
+  echo "recent pipelineruns: $recent_pipelineruns"
+
+  echo 'Get pods that need to be deleted, pods with tekton.dev/memberOf label:'
+  get_pipelinerun_pods_to_file "${pods_to_delete_file_path}"
+  cat "${pods_to_delete_file_path}"
+
+  echo 'Exclude pods of the active and recent pipelineruns from deletion list':
+  delete_lines_from_file "${pods_to_delete_file_path}" "${active_pipelineruns}"
+  delete_lines_from_file "${pods_to_delete_file_path}" "${recent_pipelineruns}"
+  cat "${pods_to_delete_file_path}"
+
+  echo 'Get PVCs that were used by pipelineruns and now need to be deleted:'
+  get_pipelinerun_pvcs_to_file "${pvcs_to_delete_file_path}" "${separator}" "${pvc_owner_kind}"
+  cat "${pvcs_to_delete_file_path}"
+
+  echo 'Exclude PVCs of the active and recent pipelineruns from deletion list:'
+  delete_lines_from_file "${pvcs_to_delete_file_path}" "${active_pipelineruns}"
+  delete_lines_from_file "${pvcs_to_delete_file_path}" "${recent_pipelineruns}"
+  cat "${pvcs_to_delete_file_path}"
+
+  echo 'Remove owner info from PVCs list'
+  sed -i "s,${separator}.*,," "${pvcs_to_delete_file_path}"
+
+  echo 'Delete pods'
+  prune_resources "${pods_to_delete_file_path}" ''
+  echo 'Ok'
+
+  echo 'Delete pvcs'
+  prune_resources "${pvcs_to_delete_file_path}" 'pvc/'
+  echo 'Ok'
+}
+
+main

--- a/charts/pipelines-library/templates/resources/pruner/cron-job.yaml
+++ b/charts/pipelines-library/templates/resources/pruner/cron-job.yaml
@@ -1,4 +1,5 @@
 {{ if .Values.tekton.pruner.create }}
+---
 apiVersion: batch/v1
 kind: CronJob
 metadata:
@@ -6,46 +7,39 @@ metadata:
   labels:
     {{- include "edp-tekton.labels" . | nindent 4 }}
 spec:
-  schedule: {{ .Values.tekton.pruner.schedule }}
-  concurrencyPolicy: Forbid
+  schedule: {{ default "0 * * * *" .Values.tekton.pruner.schedule | quote }}
+  suspend: {{ default "false" .Values.tekton.pruner.disableJob }}
+  concurrencyPolicy: {{ default "Forbid" .Values.tekton.pruner.concurrencyPolicy }}
   jobTemplate:
     spec:
-      backoffLimit: 3
+      backoffLimit: {{ default (int 3) .Values.tekton.pruner.backoffLimit }}
       template:
         spec:
+          volumes:
+            - name: scripts
+              secret:
+                secretName: tekton-resource-pruner-scripts
           containers:
-            - name: pruner-tkn-tekton-pipelines
-              image: >-
-                gcr.io/tekton-releases/dogfooding/tkn@sha256:025de221fb059ca24a3b2d988889ea34bce48dc76c0cf0d6b4499edb8c21325f
+            - name: kubectl
+              image: "{{ default "bitnami/kubectl:latest" .Values.tekton.pruner.image }}"
+              env:
+                - name: NAMESPACE
+                  valueFrom:
+                    fieldRef:
+                      apiVersion: v1
+                      fieldPath: metadata.namespace
+                - name: RECENT_MINUTES
+                  value: {{ default 30 .Values.tekton.pruner.recentMinutes | quote }}
               command:
-                - /bin/sh
-                - '-c'
-                - |
-                  function prune() {
-                      n=$1;
-                      a=$2;
-                      r=$3;
-                      #old_ifs=" ";
-                      #IFS=$'\n';
-                      pipeline_list=$(tkn pipeline list -o jsonpath='{range .items[*]}{.metadata.name}{" "}')
-                      for p in $pipeline_list;
-                      do
-                          tkn $r delete --namespace $n --pipeline $p $a -f || true;
-                      done; 
-                      #IFS=$old_ifs;
-                  };
-                  for c in $*; 
-                  do 
-                      ns=$(echo $c | cut -d ";" -f 1);
-                      args=$(echo $c | cut -d ";" -f 2);
-                      resources=$(echo $c | cut -d ";" -f 3);
-                      prune $ns $args $resources; 
-                  done;
-              args:
-                - '-s'
-                - ' {{ .Release.Namespace }};--keep={{ .Values.tekton.pruner.keep }};{{ .Values.tekton.pruner.resources }}'
-              imagePullPolicy: IfNotPresent
-          restartPolicy: OnFailure
+                - bash
+                - /scripts/tekton-prune.sh
+              volumeMounts: [{name: scripts, mountPath: /scripts}]
+              resources:
+                {{- toYaml .Values.tekton.pruner.resources | nindent 16 }}
+          restartPolicy: {{ default "OnFailure" .Values.tekton.pruner.restartPolicy }}
           serviceAccountName: tekton-resource-pruner
-      ttlSecondsAfterFinished: 3600
+          serviceAccount: tekton-resource-pruner
+      ttlSecondsAfterFinished: {{ default (int 10) .Values.tekton.pruner.ttlSecondsAfterFinished }}
+  successfulJobsHistoryLimit: {{ default (int 3) .Values.tekton.pruner.successfulJobsHistoryLimit }}
+  failedJobsHistoryLimit: {{ default (int 1) .Values.tekton.pruner.failedJobsHistoryLimit }}
 {{ end }}

--- a/charts/pipelines-library/templates/resources/pruner/rbac.yaml
+++ b/charts/pipelines-library/templates/resources/pruner/rbac.yaml
@@ -15,12 +15,29 @@ metadata:
 rules:
   - apiGroups:
       - tekton.dev
-    resources:
-      - pipelines
-      - pipelineruns
     verbs:
+      - get
       - list
+    resources:
+      - pipelineruns
+  - apiGroups:
+      - ''
+    verbs:
+      - get
+    resources:
+      - secrets
+    resourceNames:
+      - tekton-resource-pruner-scripts
+  - apiGroups:
+      - ''
+    verbs:
+      - get
+      - list
+      - watch
       - delete
+    resources:
+      - pods
+      - persistentvolumeclaims
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding

--- a/charts/pipelines-library/templates/resources/pruner/secret.yaml
+++ b/charts/pipelines-library/templates/resources/pruner/secret.yaml
@@ -1,0 +1,12 @@
+{{ if .Values.tekton.pruner.create }}
+---
+kind: Secret
+apiVersion: v1
+type: Opaque
+metadata:
+  name: tekton-resource-pruner-scripts
+  labels:
+    {{- include "edp-tekton.labels" . | nindent 4 }}
+data:
+{{ (.Files.Glob "scripts/tekton-prune.sh").AsSecrets | indent 2 }}
+{{ end }}

--- a/charts/pipelines-library/values.yaml
+++ b/charts/pipelines-library/values.yaml
@@ -55,11 +55,14 @@ tekton:
     # -- Specifies whether a cronjob should be created
     create: true
     # -- How often to clean up resources
-    schedule: "0 18 * * *"
-    # -- Maximum number of resources to keep while deleting removing
-    keep: 1
-    # -- Supported resource for auto prune is 'pipelinerun'
-    resources: "pipelinerun"
+    schedule: "0 * * * *"
+    # -- Resources of PipelineRuns that finished in the last N minutes are not pruned
+    recentMinutes: "30"
+    # -- Docker image to run the pruner, expected to have kubectl and jq
+    image: bitnami/kubectl:1.25
+    # -- Pod resources for Tekton pruner job
+    resources: {}
+
   # -- Tekton workspace size. Most cases 1Gi is enough. It's common for all pipelines
   workspaceSize: "3Gi"
   # -- The resource limits and requests for the Tekton Tasks


### PR DESCRIPTION
# Pull Request

## Description
The change replaces removal of the whole PipelineRun and all of it's resources with removal of only Pods and PVCs.
This allows preserving history of PipelineRuns in Tekton Dashboard.
Also this enables automated removal of workspace volumes, for example EBS Volumes in AWS when AWS EBS CSI Controller is used.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How Has This Been Tested?

- Chart linting performed with `helm lint`.
- The `pipelines-library` helm chart was checked with Chart Testing `ct lint`.
- All the `tekton-resource-pruner`-related templates of the  `pipelines-library` helm chart were rendered with this `helm template` command:
  ```sh
  helm template tekton-resource-pruner -n $namespace \
  ./charts/pipelines-library -s templates/resources/pruner/* > /tmp/tekton-resource-pruner.yaml
  ```
- The rendered templates were deployed to a Kubernetes cluster:
  ```sh
  kubectl apply -f /tmp/tekton-resource-pruner.yaml -n $namespace
  ```
- The job was observed to launch both on schedule and manually several times with the correct actions performed and no errors in log output.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
