### PR TITLE
feat: Exclude pipelinerun from resources displayed in argocd(#169)

### DIFF
--- a/charts/custom-pipelines/templates/cd/deploy-custom.yaml
+++ b/charts/custom-pipelines/templates/cd/deploy-custom.yaml
@@ -26,6 +26,8 @@ spec:
           app.edp.epam.com/cdpipeline: $(tt.params.CDPIPELINE)
           app.edp.epam.com/cdstage: $(tt.params.CDPIPELINE)-$(tt.params.CDSTAGE)
           app.edp.epam.com/pipelinetype: deploy
+        annotations:
+          argocd.argoproj.io/compare-options: IgnoreExtraneous
       spec:
         taskRunTemplate:
           serviceAccountName: tekton

--- a/charts/pipelines-library/templates/triggers/cd/deploy-with-autotests.yaml
+++ b/charts/pipelines-library/templates/triggers/cd/deploy-with-autotests.yaml
@@ -26,6 +26,8 @@ spec:
           app.edp.epam.com/cdpipeline: $(tt.params.CDPIPELINE)
           app.edp.epam.com/cdstage: $(tt.params.CDPIPELINE)-$(tt.params.CDSTAGE)
           app.edp.epam.com/pipelinetype: deploy
+        annotations:
+          argocd.argoproj.io/compare-options: IgnoreExtraneous
       spec:
         taskRunTemplate:
           serviceAccountName: tekton

--- a/charts/pipelines-library/templates/triggers/cd/deploy.yaml
+++ b/charts/pipelines-library/templates/triggers/cd/deploy.yaml
@@ -26,6 +26,8 @@ spec:
           app.edp.epam.com/cdpipeline: $(tt.params.CDPIPELINE)
           app.edp.epam.com/cdstage: $(tt.params.CDPIPELINE)-$(tt.params.CDSTAGE)
           app.edp.epam.com/pipelinetype: deploy
+        annotations:
+          argocd.argoproj.io/compare-options: IgnoreExtraneous
       spec:
         taskRunTemplate:
           serviceAccountName: tekton

--- a/charts/pipelines-library/templates/triggers/gerrit/tt-build.yaml
+++ b/charts/pipelines-library/templates/triggers/gerrit/tt-build.yaml
@@ -46,6 +46,8 @@ spec:
           app.edp.epam.com/codebasebranch: $(tt.params.codebasebranch)
           app.edp.epam.com/codebase: $(tt.params.codebase)
           app.edp.epam.com/pipelinetype: build
+        annotations:
+          argocd.argoproj.io/compare-options: IgnoreExtraneous
       spec:
         taskRunTemplate:
           serviceAccountName: tekton

--- a/charts/pipelines-library/templates/triggers/gerrit/tt-review.yaml
+++ b/charts/pipelines-library/templates/triggers/gerrit/tt-review.yaml
@@ -42,6 +42,8 @@ spec:
           app.edp.epam.com/codebasebranch: $(tt.params.codebasebranch)
           app.edp.epam.com/codebase: $(tt.params.codebase)
           app.edp.epam.com/pipelinetype: review
+        annotations:
+          argocd.argoproj.io/compare-options: IgnoreExtraneous
       spec:
         taskRunTemplate:
           serviceAccountName: tekton

--- a/charts/pipelines-library/templates/triggers/github/tt-build.yaml
+++ b/charts/pipelines-library/templates/triggers/github/tt-build.yaml
@@ -42,6 +42,8 @@ spec:
           app.edp.epam.com/codebasebranch: $(tt.params.codebasebranch)
           app.edp.epam.com/codebase: $(tt.params.codebase)
           app.edp.epam.com/pipelinetype: build
+        annotations:
+          argocd.argoproj.io/compare-options: IgnoreExtraneous
       spec:
         taskRunTemplate:
           serviceAccountName: tekton

--- a/charts/pipelines-library/templates/triggers/github/tt-review.yaml
+++ b/charts/pipelines-library/templates/triggers/github/tt-review.yaml
@@ -40,6 +40,8 @@ spec:
           app.edp.epam.com/codebasebranch: $(tt.params.codebasebranch)
           app.edp.epam.com/codebase: $(tt.params.codebase)
           app.edp.epam.com/pipelinetype: review
+        annotations:
+          argocd.argoproj.io/compare-options: IgnoreExtraneous
       spec:
         taskRunTemplate:
           serviceAccountName: tekton

--- a/charts/pipelines-library/templates/triggers/gitlab/tt-build.yaml
+++ b/charts/pipelines-library/templates/triggers/gitlab/tt-build.yaml
@@ -42,6 +42,8 @@ spec:
           app.edp.epam.com/codebasebranch: $(tt.params.codebasebranch)
           app.edp.epam.com/codebase: $(tt.params.codebase)
           app.edp.epam.com/pipelinetype: build
+        annotations:
+          argocd.argoproj.io/compare-options: IgnoreExtraneous
       spec:
         taskRunTemplate:
           serviceAccountName: tekton

--- a/charts/pipelines-library/templates/triggers/gitlab/tt-review.yaml
+++ b/charts/pipelines-library/templates/triggers/gitlab/tt-review.yaml
@@ -40,6 +40,8 @@ spec:
           app.edp.epam.com/codebasebranch: $(tt.params.codebasebranch)
           app.edp.epam.com/codebase: $(tt.params.codebase)
           app.edp.epam.com/pipelinetype: review
+        annotations:
+          argocd.argoproj.io/compare-options: IgnoreExtraneous
       spec:
         taskRunTemplate:
           serviceAccountName: tekton


### PR DESCRIPTION
Description
This patch introduces an enhancement that excludes the display of PipelineRun resources in the ArgoCD interface. The main purpose of this change is to prevent clutter and confusion caused by extraneous diff output, making the ArgoCD UI more streamlined and focused on relevant resources. This is achieved by adding a specific annotation (argocd.argoproj.io/compare-options: IgnoreExtraneous) to the PipelineRun resources within various templates.

Fixes #169

Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

How Has This Been Tested?
The change has been tested by deploying the modified templates and confirming that the PipelineRun resources no longer appear in the ArgoCD resources UI. Automated tests were also run to ensure existing functionality remains unaffected.

Checklist:
- [x]  I have performed a self-review of my own code
- [ ]  I have commented my code, particularly in hard-to-understand areas
- [x]  I have made corresponding changes to the documentation
- [x]  My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Pull Request contains one commit. I squash my commits.