### PR TITLE
feat: Enhance Gradle proxy support (#132)

### DIFF
--- a/charts/pipelines-library/README.md
+++ b/charts/pipelines-library/README.md
@@ -127,6 +127,7 @@ Follows [Tekton Interceptor](https://tekton.dev/vault/triggers-main/clusterinter
 | nameOverride | string | `""` |  |
 | tekton-cache.enabled | bool | `true` | Enables the Tekton-cache subchart. |
 | tekton-cache.url | string | `"http://tekton-cache:8080"` | Defines the URL to the tekton-cache. Default: http://tekton-cache:8080 |
+| tekton.configs.gradleConfigMap | string | `"custom-gradle-settings"` | Default configuration maps for provisioning init.gradle file, REPOSITORY_SNAPSHOTS_PATH and REPOSITORY_RELEASES_PATH environment variables. |
 | tekton.configs.mavenConfigMap | string | `"custom-maven-settings"` | Default configuration map for provisioning Maven settings.xml file. To use custom Maven settings.xml configuration file, the user should prepare another configuration map and update "mavenConfigMap". For reference see https://github.com/epam/edp-tekton/blob/master/charts/pipelines-library/templates/resources/cm-maven-settings.yaml |
 | tekton.configs.npmConfigMap | string | `"custom-npm-settings"` | Default configuration maps for provisioning NPM .npmrc files. To use custom NPM .npmrc configuration file, the user should prepare another configuration map and update "npmConfigMap". For reference see https://github.com/epam/edp-tekton/blob/master/charts/pipelines-library/templates/resources/cm-npm-settings.yaml |
 | tekton.configs.nugetConfigMap | string | `"custom-nuget-settings"` | Default configuration maps for provisioning nuget.config file. |

--- a/charts/pipelines-library/templates/resources/cm-gradle-settings.yaml
+++ b/charts/pipelines-library/templates/resources/cm-gradle-settings.yaml
@@ -1,3 +1,8 @@
+{{- $configs := (.Values.tekton.configs | default dict) }}
+{{- $settingsConfigMap := $configs.gradleConfigMap | default "" }}
+{{- if eq $settingsConfigMap "custom-gradle-settings" }}
+# Default configuration map for provisioning Gradle init.gradle file.
+# To change it, prepare another configuration map and update "tekton.configs.gradleConfigMap"
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -6,7 +11,7 @@ metadata:
     {{- include "edp-tekton.labels" . | nindent 4 }}
 data:
   init.gradle: |
-    // Copyright 2022 EPAM Systems.
+    // Copyright 2024 EPAM Systems.
     //
     // Licensed under the Apache License, Version 2.0 (the "License");
     // you may not use this file except in compliance with the License.
@@ -24,17 +29,56 @@ data:
         buildscript {
             repositories {
                 maven {
-                    name "maven-group"
+                    name "nexus"
                     credentials {
-                        username nexusLogin
-                        password nexusPassword
+                        username = System.getenv("CI_USERNAME")
+                        password = System.getenv("CI_PASSWORD")
                     }
-                    url "${nexusMavenRepositoryUrl}"
+                    url = System.getenv("NEXUS_HOST_URL") + "/repository/edp-maven-group"
                     allowInsecureProtocol = true
                 }
             }
             dependencies {
                 classpath "org.sonarsource.scanner.gradle:sonarqube-gradle-plugin:3.3"
+            }
+        }
+
+        repositories {
+            maven {
+                name "nexus"
+                credentials {
+                    username = System.getenv("CI_USERNAME")
+                    password = System.getenv("CI_PASSWORD")
+                }
+                url = System.getenv("NEXUS_HOST_URL") + "/repository/edp-maven-group"
+                allowInsecureProtocol = true
+            }
+            maven {
+                name "gitlab-registry"
+                url = "https://gitlab.example.com/api/v4/projects/PROJECT_ID/packages/maven"
+                credentials(HttpHeaderCredentials) {
+                    name = System.getenv("CI_GITLAB_TOKEN_TYPE")
+                    value = System.getenv("CI_GITLAB_TOKEN")
+                }
+                authentication {
+                    header(HttpHeaderAuthentication)
+                }
+            }
+            maven {
+                name "github-registry"
+                url = "https://maven.pkg.github.com/OWNER/REPOSITORY"
+                credentials {
+                    username = System.getenv("CI_GITHUB_USERNAME")
+                    password = System.getenv("CI_GITHUB_PASSWORD")
+                }
+            }
+            maven {
+                name "azure-devops-registry"
+                url 'https://pkgs.dev.azure.com'
+                credentials {
+                    username = System.getenv("CI_AZURE_DEVOPS_USERNAME")
+                    password = System.getenv("CI_AZURE_DEVOPS_PASSWORD")
+                }
             }
         }
 
@@ -46,3 +90,4 @@ data:
             project.apply plugin: 'org.sonarqube'
         }
     }
+{{- end }}

--- a/charts/pipelines-library/templates/tasks/edp-gradle.yaml
+++ b/charts/pipelines-library/templates/tasks/edp-gradle.yaml
@@ -36,13 +36,18 @@ spec:
   volumes:
     - name: settings-gradle
       configMap:
-        name: custom-gradle-settings
+        name: {{ .Values.tekton.configs.gradleConfigMap }}
   steps:
     - name: compile
       image: $(params.BASE_IMAGE)
       volumeMounts:
         - name: settings-gradle
           mountPath: /var/configmap
+      {{- if .Values.tekton.packageRegistriesSecret.enabled }}
+      envFrom:
+        - secretRef:
+            name: {{ .Values.tekton.packageRegistriesSecret.name }}
+      {{- end }}
       workingDir: $(workspaces.source.path)/$(params.PROJECT_DIR)
       script: |
         #!/bin/bash
@@ -82,6 +87,11 @@ spec:
       volumeMounts:
         - name: settings-gradle
           mountPath: /var/configmap
+      {{- if .Values.tekton.packageRegistriesSecret.enabled }}
+      envFrom:
+        - secretRef:
+            name: {{ .Values.tekton.packageRegistriesSecret.name }}
+      {{- end }}
       workingDir: $(workspaces.source.path)/$(params.PROJECT_DIR)
       script: |
         #!/bin/bash
@@ -120,6 +130,11 @@ spec:
       volumeMounts:
         - name: settings-gradle
           mountPath: /var/configmap
+      {{- if .Values.tekton.packageRegistriesSecret.enabled }}
+      envFrom:
+        - secretRef:
+            name: {{ .Values.tekton.packageRegistriesSecret.name }}
+      {{- end }}
       workingDir: $(workspaces.source.path)/$(params.PROJECT_DIR)
       script: |
         #!/bin/bash

--- a/charts/pipelines-library/templates/tasks/gradle.yaml
+++ b/charts/pipelines-library/templates/tasks/gradle.yaml
@@ -42,13 +42,18 @@ spec:
   volumes:
     - name: settings-gradle
       configMap:
-        name: custom-gradle-settings
+        name: {{ .Values.tekton.configs.gradleConfigMap }}
   steps:
     - name: gradle-tasks
       image: $(params.BASE_IMAGE)
       volumeMounts:
         - name: settings-gradle
           mountPath: /var/configmap
+      {{- if .Values.tekton.packageRegistriesSecret.enabled }}
+      envFrom:
+        - secretRef:
+            name: {{ .Values.tekton.packageRegistriesSecret.name }}
+      {{- end }}
       workingDir: $(workspaces.source.path)/$(params.PROJECT_DIR)
       script: |
         #!/bin/bash

--- a/charts/pipelines-library/templates/tasks/sonar/sonarqube-gradle.yaml
+++ b/charts/pipelines-library/templates/tasks/sonar/sonarqube-gradle.yaml
@@ -67,7 +67,7 @@ spec:
   volumes:
     - name: settings-gradle
       configMap:
-        name: custom-gradle-settings
+        name: {{ .Values.tekton.configs.gradleConfigMap }}
   steps:
     - image: epamedp/tekton-autotest:0.1.3
       name: prepare-project
@@ -102,6 +102,11 @@ spec:
       volumeMounts:
         - name: settings-gradle
           mountPath: /var/configmap
+      {{- if .Values.tekton.packageRegistriesSecret.enabled }}
+      envFrom:
+        - secretRef:
+            name: {{ .Values.tekton.packageRegistriesSecret.name }}
+      {{- end }}
       workingDir: $(workspaces.source.path)/$(params.PROJECT_DIR)
       script: |
         #!/bin/bash

--- a/charts/pipelines-library/values.yaml
+++ b/charts/pipelines-library/values.yaml
@@ -84,6 +84,10 @@ tekton:
     # To use custom Maven settings.xml configuration file, the user should prepare another configuration map and update "mavenConfigMap".
     # For reference see https://github.com/epam/edp-tekton/blob/master/charts/pipelines-library/templates/resources/cm-maven-settings.yaml
     mavenConfigMap: "custom-maven-settings"
+    # To use custom init.gradle file, the user should prepare another configuration map and update "gradleConfigMap".
+    # For reference see https://github.com/epam/edp-tekton/blob/master/charts/pipelines-library/templates/resources/cm-gradle-settings.yaml.
+    # -- Default configuration maps for provisioning init.gradle file, REPOSITORY_SNAPSHOTS_PATH and REPOSITORY_RELEASES_PATH environment variables.
+    gradleConfigMap: "custom-gradle-settings"
     # -- Default configuration maps for provisioning NPM .npmrc files.
     # To use custom NPM .npmrc configuration file, the user should prepare another configuration map and update "npmConfigMap".
     # For reference see https://github.com/epam/edp-tekton/blob/master/charts/pipelines-library/templates/resources/cm-npm-settings.yaml


### PR DESCRIPTION
- Enable conditional environment variable injection in Gradle tasks through `.Values.tekton.packageRegistriesSecret.enabled`.

- Add `gradleConfigMap: "custom-gradle-settings"` to `tekton` configs, allowing for custom Gradle settings that facilitate access to artifact storages as proxies.

- Refactor `custom-gradle-settings` ConfigMap with an updated `init.gradle` script. It dynamically configures credentials for Nexus, GitLab, GitHub, and Azure DevOps, ensuring secure and flexible integration.