### PR TITLE
fix: multiple eventListeners route creation

### DIFF
--- a/charts/pipelines-library/templates/resources/route-eventlistener.yaml
+++ b/charts/pipelines-library/templates/resources/route-eventlistener.yaml
@@ -26,5 +26,6 @@ spec:
     targetPort: http-listener
   wildcardPolicy: None
 {{- end }}
+---
 {{- end }}
 {{- end }}


### PR DESCRIPTION
Description
This change addresses the issue where the EDP-Tekton pipeline library was creating only a single eventListener route resource on OpenShift, regardless of the number of git servers configured with eventListener ingress enabled. The fix involves modifying the Helm chart template to iterate over the gitServers values and create a unique OpenShift Route for each eligible git server. This ensures that each eventListener has its own route for proper functionality and accessibility.

Fixes # (issue reference not provided, please include if available)

Type of change
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

How Has This Been Tested?

The changes have been tested by deploying the updated Helm chart to an OpenShift cluster and verifying that a Route is successfully created for each git server with eventListener ingress enabled. The tests included checking the route accessibility and ensuring that eventListeners are reachable through their respective routes.

Checklist:
 - [x] I have performed a self-review of my own code
 - [x] I have commented my code, particularly in hard-to-understand areas
 - [x] I have made corresponding changes to the documentation (if applicable, please specify)
 - [x] My changes generate no new warnings
 - [ ] I have added tests that prove my fix is effective or that my feature works
 - [ ] New and existing unit tests pass locally with my changes
 - [x] Pull Request contain one commit. I squash my commits.