### PR TITLE
feat: Dynamically set repository URLs for package types (#132)

### DIFF
--- a/charts/pipelines-library/templates/pipelines/_common_java_gradle.yaml
+++ b/charts/pipelines-library/templates/pipelines/_common_java_gradle.yaml
@@ -28,7 +28,6 @@
       value: $(params.CODEBASE_NAME)
     - name: EXTRA_COMMANDS
       value: |
-        -PnexusMavenRepositoryUrl=${NEXUS_HOST_URL}/repository/edp-maven-group \
         -Dsonar.projectKey=$(params.CODEBASE_NAME) \
         -Dsonar.projectName=$(params.CODEBASE_NAME) \
         -Dsonar.host.url=${SONAR_HOST_URL} \
@@ -65,8 +64,9 @@
     - name: EXTRA_ARGS
       value: |
         -Dorg.gradle.internal.publish.checksums.insecure=true \
-        -PnexusMavenRepositoryUrl=$(tasks.get-nexus-repository-url.results.NEXUS_REPOSITORY_URL) \
-        publish
+        -PsnapshotsRepoUrl=${NEXUS_HOST_URL}${SNAPSHOTS_REPO_PATH} \
+        -PreleasesRepoUrl=${NEXUS_HOST_URL}${RELEASES_REPO_PATH} \
+        publish -i
   workspaces:
     - name: source
       workspace: shared-workspace
@@ -102,7 +102,6 @@
       value: $(params.CODEBASE_NAME)
     - name: EXTRA_COMMANDS
       value: |
-        -PnexusMavenRepositoryUrl=${NEXUS_HOST_URL}/repository/edp-maven-group \
         -Dsonar.projectKey=$(params.CODEBASE_NAME) \
         -Dsonar.projectName=$(params.CODEBASE_NAME) \
         -Dsonar.host.url=${SONAR_HOST_URL} \
@@ -146,7 +145,6 @@
       value: $(params.CODEBASE_NAME)
     - name: EXTRA_COMMANDS
       value: |
-        -PnexusMavenRepositoryUrl=${NEXUS_HOST_URL}/repository/edp-maven-group \
         -Dsonar.projectKey=$(params.CODEBASE_NAME) \
         -Dsonar.projectName=$(params.CODEBASE_NAME) \
         -Dsonar.host.url=${SONAR_HOST_URL} \

--- a/charts/pipelines-library/templates/resources/cm-gradle-settings.yaml
+++ b/charts/pipelines-library/templates/resources/cm-gradle-settings.yaml
@@ -10,6 +10,8 @@ metadata:
   labels:
     {{- include "edp-tekton.labels" . | nindent 4 }}
 data:
+  SNAPSHOTS_REPO_PATH: "/repository/edp-maven-snapshots"
+  RELEASES_REPO_PATH: "/repository/edp-maven-releases"
   init.gradle: |
     // Copyright 2024 EPAM Systems.
     //

--- a/charts/pipelines-library/templates/tasks/edp-gradle.yaml
+++ b/charts/pipelines-library/templates/tasks/edp-gradle.yaml
@@ -56,9 +56,6 @@ spec:
         gradle \
           -I \
           /var/configmap/init.gradle \
-          -PnexusLogin=${CI_USERNAME} \
-          -PnexusPassword=${CI_PASSWORD} \
-          -PnexusMavenRepositoryUrl=${NEXUS_HOST_URL}/repository/edp-maven-group \
             clean \
             compileJava \
             -x test
@@ -100,9 +97,6 @@ spec:
         gradle \
           -I \
           /var/configmap/init.gradle \
-          -PnexusLogin=${CI_USERNAME} \
-          -PnexusPassword=${CI_PASSWORD} \
-          -PnexusMavenRepositoryUrl=${NEXUS_HOST_URL}/repository/edp-maven-group \
             test \
             jacocoTestReport
       env:
@@ -143,9 +137,6 @@ spec:
         gradle \
           -I \
           /var/configmap/init.gradle \
-          -PnexusLogin=${CI_USERNAME} \
-          -PnexusPassword=${CI_PASSWORD} \
-          -PnexusMavenRepositoryUrl=${NEXUS_HOST_URL}/repository/edp-maven-group \
             build -x test
       env:
         - name: XDG_CONFIG_HOME

--- a/charts/pipelines-library/templates/tasks/gradle.yaml
+++ b/charts/pipelines-library/templates/tasks/gradle.yaml
@@ -97,4 +97,16 @@ spec:
             secretKeyRef:
               name: $(params.ci-nexus)
               key: url
+        - name: SNAPSHOTS_REPO_PATH
+          valueFrom:
+            configMapKeyRef:
+              name: {{ .Values.tekton.configs.gradleConfigMap }}
+              key: SNAPSHOTS_REPO_PATH
+              optional: true
+        - name: RELEASES_REPO_PATH
+          valueFrom:
+            configMapKeyRef:
+              name: {{ .Values.tekton.configs.gradleConfigMap }}
+              key: RELEASES_REPO_PATH
+              optional: true
 {{- include "resources" . | nindent 6 }}


### PR DESCRIPTION
# Pull Request Template

## Description
This PR aims to dynamically set repository URLs for package types. It introduces changes that remove explicit Nexus credentials (`nexusLogin`, `nexusPassword`, and `nexusMavenRepositoryUrl`) from Gradle command lines in build, test, and compile tasks. Moreover, it incorporates `SNAPSHOTS_REPO_PATH` and `RELEASES_REPO_PATH` into the `custom-gradle-settings` ConfigMap, allowing for dynamic configuration of repository URLs based on the build context. A `configMapKeyRef` has been added to the Gradle task to enable dynamic retrieval of Nexus URL, snapshots, and releases repository paths from the Kubernetes ConfigMap.

Fixes #132

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?
The description does not provide specific details on tests. It's recommended to describe the tests that were conducted to ensure the changes are effective and provide instructions on how to replicate the testing process.

## Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] Pull Request contains one commit. I squash my commits.

## Screenshots (if appropriate):
Not applicable.

## Additional context
Not provided.