### PR TITLE
chore: Update tekton-dashboard(#180)

### DIFF
--- a/charts/pipelines-library/README.md
+++ b/charts/pipelines-library/README.md
@@ -77,7 +77,7 @@ Follows [Tekton Interceptor](https://tekton.dev/vault/triggers-main/clusterinter
 | dashboard.affinity | object | `{}` | Affinity settings for pod assignment |
 | dashboard.enabled | bool | `true` | Deploy EDP Dashboard as a part of pipeline library when true. Default: true |
 | dashboard.image.repository | string | `"gcr.io/tekton-releases/github.com/tektoncd/dashboard/cmd/dashboard"` | Define tekton dashboard docker image name |
-| dashboard.image.tag | string | `"v0.43.1"` | Define tekton dashboard docker image tag |
+| dashboard.image.tag | string | `"v0.46.0"` | Define tekton dashboard docker image tag |
 | dashboard.ingress.annotations | object | `{}` | Annotations for Ingress resource |
 | dashboard.ingress.enabled | bool | `true` | Enable external endpoint access. Default Ingress/Route host pattern: tekton-{{ .Release.Namespace }}.{{ .Values.global.dnsWildCard }} |
 | dashboard.ingress.tls | list | `[]` | Uncomment it to enable tekton-dashboard OIDC on EKS cluster nginx.ingress.kubernetes.io/auth-signin: 'https://<oauth-ingress-host>/oauth2/start?rd=https://$host$request_uri' nginx.ingress.kubernetes.io/auth-url: 'http://oauth2-proxy.<edp-project>.svc.cluster.local:8080/oauth2/auth' |

--- a/charts/pipelines-library/templates/dashboard/deployment.yaml
+++ b/charts/pipelines-library/templates/dashboard/deployment.yaml
@@ -70,7 +70,7 @@ spec:
             - --log-format=json
             - --stream-logs=true
             - --external-logs=
-            - --namespace={{ .Release.Namespace }}
+            - --namespaces={{ .Release.Namespace }}
           env:
             - name: INSTALLED_NAMESPACE
               valueFrom:

--- a/charts/pipelines-library/values.yaml
+++ b/charts/pipelines-library/values.yaml
@@ -314,7 +314,7 @@ dashboard:
     # -- Define tekton dashboard docker image name
     repository: gcr.io/tekton-releases/github.com/tektoncd/dashboard/cmd/dashboard
     # -- Define tekton dashboard docker image tag
-    tag: v0.43.1
+    tag: v0.46.0
 
   ingress:
     # -- Enable external endpoint access. Default Ingress/Route host pattern: tekton-{{ .Release.Namespace }}.{{ .Values.global.dnsWildCard }}


### PR DESCRIPTION
Description
This pull request updates the Tekton dashboard version to v0.46.0 and aligns the pod arguments to use --namespaces instead of the previously incorrect --namespace. This change ensures that the Tekton pipeline library is using the current application version of the Tekton dashboard, adhering to the acceptance criteria of keeping the application up-to-date and ensuring the arguments are correctly specified according to the latest specifications.

Type of change

 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [х] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
 
How Has This Been Tested?

The changes were tested in a development environment where the Tekton dashboard deployment was successfully updated to version v0.46.0, and the pods were correctly picking up the --namespaces argument, ensuring that the dashboard operates within the correct namespace context.

Steps to reproduce:

Deploy the updated Helm chart to a Kubernetes cluster.
Verify the Tekton dashboard version through the UI and the pod's logs to ensure it's running version v0.46.0.
Check the dashboard pod's startup arguments to confirm that --namespaces is used and aligned with the namespace provided during the Helm chart deployment.

Checklist:
 - [х]I have performed a self-review of my own code
 - [ ] I have commented my code, particularly in hard-to-understand areas
 - [ ] I have made corresponding changes to the documentation
 - [ ] My changes generate no new warnings
 - [ ] I have added tests that prove my fix is effective or that my feature works
 - [ ] New and existing unit tests pass locally with my changes
 - [х] Pull Request contains one commit. I squash my commits.
