### PR TITLE
fix: Make possible work with registry without registry parameter(#184)

### DIFF
--- a/charts/pipelines-library/templates/tasks/helm-libraries/helm-push-lib.yaml
+++ b/charts/pipelines-library/templates/tasks/helm-libraries/helm-push-lib.yaml
@@ -31,6 +31,7 @@ spec:
             configMapKeyRef:
               name: edp-config
               key: aws_region
+              optional: true
         - name: CHART_DIR
           value: $(params.chart-dir)
         - name: CONTAINER_REGISTRY_SPACE
@@ -71,6 +72,7 @@ spec:
             configMapKeyRef:
               name: edp-config
               key: aws_region
+              optional: true
         - name: CONTAINER_REGISTRY_URL
           valueFrom:
             configMapKeyRef:

--- a/charts/pipelines-library/templates/tasks/helm-push.yaml
+++ b/charts/pipelines-library/templates/tasks/helm-push.yaml
@@ -33,6 +33,7 @@ spec:
             configMapKeyRef:
               name: edp-config
               key: aws_region
+              optional: true
         - name: CHART_DIR
           value: $(params.chart-dir)
         - name: CONTAINER_REGISTRY_SPACE
@@ -66,6 +67,7 @@ spec:
             configMapKeyRef:
               name: edp-config
               key: aws_region
+              optional: true
         - name: CONTAINER_REGISTRY_TYPE
           valueFrom:
             configMapKeyRef:


### PR DESCRIPTION
Description
This PR introduces two minor but essential changes to the Helm push tasks for both Helm applications and libraries. Specifically, it adds an optional aws_region parameter to the tasks, allowing for more flexible configuration when dealing with different AWS regions. This enhancement ensures that our Helm push operations are more adaptable to various deployment environments, particularly when interacting with AWS services.

Type of change

- [x]  Bug fix (non-breaking change which fixes an issue)
- [ ]  New feature (non-breaking change which adds functionality)
- [ ]  Breaking change (fix or feature that would cause existing functionality to not work as expected)

How Has This Been Tested?

The changes were tested by deploying Helm charts to different AWS regions, ensuring that the aws_region parameter is correctly utilized and that the Helm push operations succeed without any issues. The tests were conducted in a development environment with configurations mimicking those of our production settings to ensure accuracy.

Test Steps:

Set the aws_region parameter in the edp-config ConfigMap to a specific AWS region.
Run the Helm push task for both a Helm library and an application.
Verify that the tasks complete successfully and the Helm charts are pushed to the correct AWS region-specific registry.

Checklist:

- [x]  I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works - Note: Depending on your project's requirements, you might need to adjust this.
- [x] New and existing unit tests pass locally with my changes
- [x] Pull Request contains one commit. I squash my commits.

