### PR TITLE
chore: Remove PR modify action for review pipeline (#187)

### DIFF
--- a/charts/pipelines-library/templates/triggers/github/trigger-review.yaml
+++ b/charts/pipelines-library/templates/triggers/github/trigger-review.yaml
@@ -20,7 +20,7 @@ spec:
         name: "cel"
       params:
         - name: "filter"
-          value: "body.action in ['opened', 'synchronize', 'edited', 'created']"
+          value: "body.action in ['opened', 'synchronize', 'created']"
     - ref:
         name: "edp"
         kind: NamespacedInterceptor


### PR DESCRIPTION
# Pull Request Template

## Description
This pull request removes the trigger for pipelines when a pull request is modified. The intention is to reduce unnecessary pipeline runs when minor edits are made to a PR. This change requires users to manually retrigger the review pipeline by commenting /recheck or by pushing new changes to the PR.

Fixes #187

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How Has This Been Tested?
Tested by making edits to existing PRs and observing that the pipeline was not triggered. Additionally, the /recheck command and pushing new commits were tested to confirm they correctly trigger the pipeline.

## Checklist:
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Pull Request contain one commit. I squash my commits.

## Screenshots (if appropriate):

## Additional context
This change aims to optimize the use of CI resources by preventing unnecessary pipeline runs, thus saving time and compute resources.