### PR TITLE
chore: Bump hadolint version to v2.12.0-alpine (#188)

### DIFF
--- a/charts/pipelines-library/templates/tasks/hadolint.yaml
+++ b/charts/pipelines-library/templates/tasks/hadolint.yaml
@@ -19,7 +19,7 @@ spec:
   params:
     - name: BASE_IMAGE
       description: The base image for the task.
-      default: ghcr.io/hadolint/hadolint:v2.8.0-debian@sha256:50b0e60aa2b4aba5a26eeb4ad08c96ed7a828fca996632e29114aabea18345f4
+      default: ghcr.io/hadolint/hadolint:v2.12.0-alpine@sha256:3c206a451cec6d486367e758645269fd7d696c5ccb6ff59d8b03b0e45268a199
     - default: './Dockerfile'
       description: Dockerfile path.
       name: dockerfile-path
@@ -43,6 +43,5 @@ spec:
         - name: OFORMAT
           value: "$(params.output-format)"
       script: |
-        #!/bin/bash
         set -e
         hadolint "$DOCKERFILE" -f "$OFORMAT"


### PR DESCRIPTION
# Pull Request Template

## Description
In this update, I changed the Docker linter image from ghcr.io/hadolint/hadolint:v2.8.0-debian to ghcr.io/hadolint/hadolint:v2.12.0-alpine. This change was necessary for several reasons: the Alpine version of the image is smaller and more secure due to fewer included packages, which aligns with our goal to optimize our CI/CD pipeline for speed and security. Additionally, the update to version 2.12.0 brings in new linting rules and bug fixes that improve the quality of our Dockerfile linting process. I also removed the #!/bin/bash shebang from the script as it was redundant. This script is intended to be run in environments where bash is the default shell, and its presence could cause issues in environments where bash is not available or not the default.

Fixes #188 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How Has This Been Tested?
I tested the update by running the modified script with a new hadolint version on several Dockerfiles.

## Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] Pull Request contain one commit. I squash my commits.