### PR TITLE
chore: Use Go 1.22 for e2e workflow

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -8,6 +8,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 
+env:
+  GOLANG_VERSION: '1.22'
+
 jobs:
   e2e-tests-127:
     name: End-to-end tests 1.27


### PR DESCRIPTION
# Pull Request Template

## Description
For push to master e2e workflow Go version is missing.
Workfllow can fail if if takes Go version not equal 1.22.

Fixes #182 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Pull Request contain one commit. I squash my commits.