### PR TITLE
chore: Use commit message instead PR title

### DIFF
--- a/charts/pipelines-library/templates/triggers/github/triggerbinding-review.yaml
+++ b/charts/pipelines-library/templates/triggers/github/triggerbinding-review.yaml
@@ -29,7 +29,7 @@ spec:
     - name: cbtype
       value: "$(extensions.cbtype_short)"
     - name: commitMessage
-      value: "$(extensions.pullRequest.title)"
+      value: "$(extensions.pullRequest.lastCommitMessage)"
     - name: commitMessagePattern
       value: "$(extensions.spec.commitMessagePattern)"
     - name: codebase

--- a/charts/pipelines-library/templates/triggers/gitlab/triggerbinding-review.yaml
+++ b/charts/pipelines-library/templates/triggers/gitlab/triggerbinding-review.yaml
@@ -29,7 +29,7 @@ spec:
     - name: commitMessagePattern
       value: "$(extensions.spec.commitMessagePattern)"
     - name: commitMessage
-      value: "$(extensions.pullRequest.title)"
+      value: "$(extensions.pullRequest.lastCommitMessage)"
     - name: codebase
       value: "$(extensions.codebase)"
     - name: codebasebranch


### PR DESCRIPTION
* In GitHub event listner sent to tekton pipeline commit message instead PR title

* In GitLab event listner sent to tekton pipeline commit message instead MR title

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] Pull Request contain one commit. I squash my commits.
