### PR TITLE
fix: Install packages via requirements (#215)

### DIFF
--- a/charts/pipelines-library/templates/pipelines/_common_python.yaml
+++ b/charts/pipelines-library/templates/pipelines/_common_python.yaml
@@ -47,7 +47,7 @@
       value: 'python:3.8-slim'
     - name: EXTRA_COMMANDS
       value: |
-        pip install twine==4.0.1
+        pip install -r requirements.txt
         python setup.py sdist
 
         # Get package version from the get-version task


### PR DESCRIPTION
Description
This PR addresses a build pipeline failure due to a KeyError: 'license' when attempting to push a Python package. The issue was traced back to the direct installation of twine in the pipeline script. By changing the installation process to use requirements.txt, we ensure all dependencies, including any necessary metadata, are correctly managed and installed, preventing the KeyError.

Fixes # (issue number not provided)

Type of change:
- [x]  Bug fix (non-breaking change which fixes an issue)

How Has This Been Tested?
- The build pipeline was re-run with the changes incorporated.
- A mock Python package was created and processed through the pipeline to ensure the KeyError: 'license' issue did not reoccur.
- All existing unit tests were executed to confirm that no existing functionalities were affected.

Checklist:
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas (Not applicable as the change is straightforward)
- [ ] I have made corresponding changes to the documentation (No documentation changes necessary)
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works (The nature of the fix does not require new tests)
- [ ] New and existing unit tests pass locally with my changes
- [x] Pull Request contains one commit. I squash my commits.