### PR TITLE
chore: Revert Update gitservers event listener name and add label (#222)

### DIFF
--- a/charts/pipelines-library/templates/resources/gitservers/eventlistener.yaml
+++ b/charts/pipelines-library/templates/resources/gitservers/eventlistener.yaml
@@ -3,7 +3,7 @@
 apiVersion: triggers.tekton.dev/v1beta1
 kind: EventListener
 metadata:
-  name: {{ $name }}
+  name: edp-{{ $name }}
   labels:
     {{- include "edp-tekton.labels" $ | nindent 4 }}
     app.edp.epam.com/gitServer: {{ $name }}

--- a/charts/pipelines-library/templates/resources/gitservers/ingress-eventlistener.yaml
+++ b/charts/pipelines-library/templates/resources/gitservers/ingress-eventlistener.yaml
@@ -33,7 +33,7 @@ spec:
             backend:
               service:
                 # The service name will come from EventListener CR
-                name: el-{{ $name }}
+                name: el-edp-{{ $name }}
                 port:
                   number: 8080
 {{- end }}

--- a/charts/pipelines-library/templates/resources/route-eventlistener.yaml
+++ b/charts/pipelines-library/templates/resources/route-eventlistener.yaml
@@ -20,7 +20,7 @@ spec:
     termination: edge
   to:
     kind: Service
-    name: el-{{ $name }}
+    name: el-edp-{{ $name }}
     weight: 100
   port:
     targetPort: http-listener

--- a/charts/pipelines-library/tests/test_baseline.py
+++ b/charts/pipelines-library/tests/test_baseline.py
@@ -66,7 +66,7 @@ gitServers:
 
     assert el_Name in r["ingress"]
     assert "el-my-gitlab-ns.example.com" in r["ingress"][el_Name]["spec"]["rules"][0]["host"]
-    assert "el-my-gitlab" in r["ingress"][el_Name]["spec"]["rules"][0]["http"]["paths"][0]["backend"]["service"]["name"]
+    assert "el-edp-my-gitlab" in r["ingress"][el_Name]["spec"]["rules"][0]["http"]["paths"][0]["backend"]["service"]["name"]
 
 
 def test_ingress_for_github_el():
@@ -113,7 +113,7 @@ gitServers:
 
     assert el_Name in r["ingress"]
     assert "el-my-github-ns.example.com" in r["ingress"][el_Name]["spec"]["rules"][0]["host"]
-    assert "el-my-github" in r["ingress"][el_Name]["spec"]["rules"][0]["http"]["paths"][0]["backend"]["service"]["name"]
+    assert "el-edp-my-github" in r["ingress"][el_Name]["spec"]["rules"][0]["http"]["paths"][0]["backend"]["service"]["name"]
 
 
 def test_ingress_for_gerrit_el():
@@ -160,7 +160,7 @@ gitServers:
 
     assert el_Name in r["ingress"]
     assert "el-my-gerrit-ns.example.com" in r["ingress"][el_Name]["spec"]["rules"][0]["host"]
-    assert "el-my-gerrit" in r["ingress"][el_Name]["spec"]["rules"][0]["http"]["paths"][0]["backend"]["service"]["name"]
+    assert "el-edp-my-gerrit" in r["ingress"][el_Name]["spec"]["rules"][0]["http"]["paths"][0]["backend"]["service"]["name"]
 
 
 def test_pruner_disabled():

--- a/charts/pipelines-library/tests/test_github_integration.py
+++ b/charts/pipelines-library/tests/test_github_integration.py
@@ -43,13 +43,11 @@ gitServers:
     r = helm_template(config)
 
     # Access the event listener using the new structure
-    el = r["eventlistener"]["my-github"]["spec"]
+    el = r["eventlistener"]["edp-my-github"]["spec"]
 
     # Check if the triggers are correctly set
     assert "github-build" == el["triggers"][0]["triggerRef"]
     assert "github-review" == el["triggers"][1]["triggerRef"]
-    # check that labels are correctly set
-    assert "my-github" == r["eventlistener"]["my-github"]["metadata"]["labels"]["app.edp.epam.com/gitServer"]
 
     gitserver = r["gitserver"]["my-github"]["spec"]
 

--- a/tests/e2e/gerrit/02-assert.yaml
+++ b/tests/e2e/gerrit/02-assert.yaml
@@ -18,6 +18,6 @@ status:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: el-my-gerrit
+  name: el-edp-my-gerrit
 status:
   readyReplicas: 1

--- a/tests/e2e/github/02-assert.yaml
+++ b/tests/e2e/github/02-assert.yaml
@@ -18,6 +18,6 @@ status:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: el-my-github
+  name: el-edp-my-github
 status:
   readyReplicas: 1

--- a/tests/e2e/gitlab/02-assert.yaml
+++ b/tests/e2e/gitlab/02-assert.yaml
@@ -18,6 +18,6 @@ status:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: el-my-gitlab
+  name: el-edp-my-gitlab
 status:
   readyReplicas: 1


### PR DESCRIPTION
This reverts commit df13f9650445e9263b1186963bc4ae8f02e48b25.

We need to keep old naming schema for better user experience

# Pull Request Template

## Description
Please include a summary of the change and why it is needed.

Fixes #222 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
