### PR TITLE
feat: Re-trigger Tekton Pipeline with /ok-to-test comment

### DIFF
--- a/pkg/event_processor/event.go
+++ b/pkg/event_processor/event.go
@@ -64,7 +64,8 @@ const (
 	EventTypeReviewComment = "comment"
 	EventTypeMerge         = "merge"
 
-	recheckComment = "/recheck"
+	RecheckComment  = "/recheck"
+	OkToTestComment = "/ok-to-test"
 )
 
 // EventInfo represents information about an event.
@@ -92,5 +93,5 @@ func (e *EventInfo) IsReviewCommentEvent() bool {
 }
 
 func ContainsPipelineRecheck(s string) bool {
-	return strings.Contains(s, recheckComment)
+	return strings.Contains(s, RecheckComment) || strings.Contains(s, OkToTestComment)
 }

--- a/pkg/event_processor/gerrit/gerrit_test.go
+++ b/pkg/event_processor/gerrit/gerrit_test.go
@@ -131,6 +131,54 @@ func TestGerritEventProcessor_Process(t *testing.T) {
 			},
 		},
 		{
+			name: "comment event process successfully - OkToTestComment",
+			kubeObjects: []client.Object{
+				&codebaseApi.Codebase{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-codebase",
+						Namespace: "default",
+					},
+					Spec: codebaseApi.CodebaseSpec{
+						GitUrlPath: pointer.String("/test-repo"),
+					},
+				},
+			},
+			args: args{
+				event_processor.GerritEvent{
+					Project: struct {
+						Name string `json:"name"`
+					}{
+						Name: "test-repo",
+					},
+					Change: struct {
+						Branch string `json:"branch"`
+					}{
+						Branch: "test-branch",
+					},
+					Type:    event_processor.GerritEventTypeCommentAdded,
+					Comment: event_processor.OkToTestComment,
+				},
+			},
+			wantErr: require.NoError,
+			want: &event_processor.EventInfo{
+				GitProvider:        event_processor.GitProviderGerrit,
+				RepoPath:           "test-repo",
+				TargetBranch:       "test-branch",
+				Type:               event_processor.EventTypeReviewComment,
+				HasPipelineRecheck: true,
+				Codebase: &codebaseApi.Codebase{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:            "test-codebase",
+						Namespace:       "default",
+						ResourceVersion: "999",
+					},
+					Spec: codebaseApi.CodebaseSpec{
+						GitUrlPath: pointer.String("/test-repo"),
+					},
+				},
+			},
+		},
+		{
 			name: "comment event with no recheck",
 			kubeObjects: []client.Object{
 				&codebaseApi.Codebase{

--- a/pkg/interceptor/edp_interceptor.go
+++ b/pkg/interceptor/edp_interceptor.go
@@ -25,7 +25,6 @@ import (
 
 const (
 	executeTimeOut = 3 * time.Second
-	recheckComment = "/recheck"
 )
 
 // EDPInterceptorInterface is an interface for EDPInterceptor.
@@ -111,7 +110,7 @@ func (i *EDPInterceptor) Process(ctx context.Context, r *triggersv1.InterceptorR
 			}
 		}
 
-		i.logger.Infof("Found pipeline %s comment, triggering pipeline", recheckComment)
+		i.logger.Infof("Found comment for recheck, triggering pipeline")
 	}
 
 	prepareCodebase(event.Codebase)


### PR DESCRIPTION
# Pull Request Template

## Description
Make it possible to re-trigger the Tekton pipeline using the "/ok-to-test" comment in pull requests. This feature will enhance the flexibility of pipeline executions by allowing developers to manually trigger the pipeline as needed when GitHub owners are enabled. This feature is equal to /recheck

Fixes #238 
## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## How Has This Been Tested?
Unit tests.

## Checklist:
- [x] I have performed a self-review of my code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Pull Request contains one commit. I squash my commits.