### PR TITLE
feat: Update jira task Include GitCommit instead of Pipeline URL(#252)

### DIFF
--- a/charts/common-library/Chart.yaml
+++ b/charts/common-library/Chart.yaml
@@ -3,8 +3,8 @@ description: A Helm chart library with common components for KubeRocketCI Tekton
 home: https://docs.kuberocketci.io
 name: edp-tekton-common-library
 type: library
-version: 0.3.1
-appVersion: 0.3.1
+version: 0.3.2
+appVersion: 0.3.2
 icon: https://docs.kuberocketci.io/img/logo.svg
 keywords:
   - edp

--- a/charts/common-library/README.md
+++ b/charts/common-library/README.md
@@ -1,6 +1,6 @@
 # edp-tekton-common-library
 
-![Version: 0.3.1](https://img.shields.io/badge/Version-0.3.1-informational?style=flat-square) ![Type: library](https://img.shields.io/badge/Type-library-informational?style=flat-square) ![AppVersion: 0.3.1](https://img.shields.io/badge/AppVersion-0.3.1-informational?style=flat-square)
+![Version: 0.3.2](https://img.shields.io/badge/Version-0.3.2-informational?style=flat-square) ![Type: library](https://img.shields.io/badge/Type-library-informational?style=flat-square) ![AppVersion: 0.3.2](https://img.shields.io/badge/AppVersion-0.3.2-informational?style=flat-square)
 [![Artifact HUB](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/epmdedp)](https://artifacthub.io/packages/search?repo=epmdedp)
 
 A Helm chart library with common components for KubeRocketCI Tekton Pipelines

--- a/charts/common-library/templates/_common.yaml
+++ b/charts/common-library/templates/_common.yaml
@@ -264,12 +264,12 @@ finally:
       value: "$(params.JIRA_ISSUE_METADATA_PAYLOAD)"
     - name: CODEBASE_NAME
       value: "$(params.CODEBASE_NAME)"
-    - name: PIPELINE_URL
-      value: "$(params.pipelineUrl)"
     - name: VCS_TAG
       value: "$(tasks.get-version.results.VCS_TAG)"
     - name: VERSION
       value: "$(tasks.get-version.results.VERSION)"
+    - name: GIT_URL
+      value: $(params.git-source-url)
 {{- end -}}
 
 {{- define "send-to-microsoft-teams-build" -}}

--- a/charts/pipelines-library/Chart.lock
+++ b/charts/pipelines-library/Chart.lock
@@ -1,9 +1,9 @@
 dependencies:
 - name: edp-tekton-common-library
   repository: file://../common-library
-  version: 0.3.1
+  version: 0.3.2
 - name: tekton-cache
   repository: https://epam.github.io/edp-helm-charts/stable
   version: 0.3.2
-digest: sha256:42c1387e7be56fc4b4621a00648030df1aaf84326bc01e7f593ae04a5b0385ed
-generated: "2024-07-18T12:27:37.793043+03:00"
+digest: sha256:c87624f27568453fcafbc80ae52e150be8a0184b661204243ba52537ad52976a
+generated: "2024-08-07T20:35:04.587201+03:00"

--- a/charts/pipelines-library/Chart.yaml
+++ b/charts/pipelines-library/Chart.yaml
@@ -38,7 +38,7 @@ annotations:
 # we use templates from common library
 dependencies:
   - name: edp-tekton-common-library
-    version: 0.3.1
+    version: 0.3.2
     repository: "file://../common-library"
   - name: tekton-cache
     version: 0.3.2

--- a/charts/pipelines-library/README.md
+++ b/charts/pipelines-library/README.md
@@ -66,7 +66,7 @@ Follows [Tekton Interceptor](https://tekton.dev/vault/triggers-main/clusterinter
 | Repository | Name | Version |
 |------------|------|---------|
 | @epamedp | tekton-cache | 0.3.2 |
-| file://../common-library | edp-tekton-common-library | 0.3.1 |
+| file://../common-library | edp-tekton-common-library | 0.3.2 |
 
 ## Values
 

--- a/charts/pipelines-library/templates/tasks/push-to-jira.yaml
+++ b/charts/pipelines-library/templates/tasks/push-to-jira.yaml
@@ -22,16 +22,19 @@ spec:
       type: string
     - name: CODEBASE_NAME
       type: string
-    - name: PIPELINE_URL
-      type: string
     - name: VCS_TAG
       type: string
     - name: VERSION
+      type: string
+    - name: GIT_URL
+      description: Repository URL to clone from.
       type: string
   steps:
     - name: push-to-jira
       image: epamedp/tekton-autotest:0.1.3
       env:
+        - name: GIT_URL
+          value: $(params.GIT_URL)
         - name: TICKET_NAME_PATTERN
           value: "$(params.TICKET_NAME_PATTERN)"
         - name: COMMIT_MESSAGE
@@ -42,8 +45,6 @@ spec:
           value: "$(params.JIRA_ISSUE_METADATA_PAYLOAD)"
         - name: CODEBASE_NAME
           value: "$(params.CODEBASE_NAME)"
-        - name: PIPELINE_URL
-          value: "$(params.PIPELINE_URL)"
         - name: VCS_TAG
           value: "$(params.VCS_TAG)"
         - name: VERSION
@@ -62,19 +63,31 @@ spec:
         commit_id = os.getenv("COMMIT_ID")
         jira_issue_metadata_payload = os.getenv("JIRA_ISSUE_METADATA_PAYLOAD")
         codebase = os.getenv("CODEBASE_NAME")
-        pipeline_url = os.getenv("PIPELINE_URL")
         vcs_tag = os.getenv("VCS_TAG")
         version = os.getenv("VERSION")
+        git_url = os.getenv("GIT_URL")
 
+        print(f"[TEKTON][DEBUG] GIT_URL: {git_url}")
         print(f"[TEKTON][DEBUG] TICKET_NAME_PATTERN: {ticket_message_pattern}")
         print(f"[TEKTON][DEBUG] COMMIT_MESSAGE: \n{commit_message_with_change_id}")
         print(f"[TEKTON][DEBUG] COMMIT_ID: {commit_id}")
         print(f"[TEKTON][DEBUG] JIRA_ISSUE_METADATA_PAYLOAD: {jira_issue_metadata_payload}")
         print(f"[TEKTON][DEBUG] CODEBASE_NAME: {codebase}")
-        print(f"[TEKTON][DEBUG] PIPELINE_URL: {pipeline_url}")
         print(f"[TEKTON][DEBUG] VCS_TAG: {vcs_tag}")
         print(f"[TEKTON][DEBUG] VERSION: {version}")
         print("")
+
+        def convert_ssh_to_https_with_commit(ssh_url, commit_id):
+            # Regular expression to extract information from SSH URLs
+            match = re.match(r"git@(.*?):(.*?)/(.*?)\.git", ssh_url)
+            if match:
+                domain, user, repo = match.groups()
+                # Construct the HTTPS address with the commit_id at the end
+                https_url = f"https://{domain}/{user}/{repo}/commit/{commit_id}"
+                return https_url
+            else:
+                # If it doesn't match the SSH pattern, return the original URL
+                return ssh_url
 
         def search_pattern(message, pattern):
             result = re.search(pattern, message)
@@ -115,6 +128,10 @@ spec:
         print("[TEKTON] Getting Ticket number and Commit message")
         ticket_number = search_pattern(commit_message_with_change_id, ticket_message_pattern)
         print(f"[TEKTON] Ticket number is {ticket_number}")
+
+        git_commit_url = convert_ssh_to_https_with_commit(git_url, commit_id)
+        print(f"[TEKTON] Git Commit URL {git_commit_url}")
+
         # Use the first line of commit message as a commit message for JiraIssueMetadata CR
         commit_message = commit_message_with_change_id.split("\n")[0]
         print(f"[TEKTON] Commit message was parsed: {commit_message}")
@@ -123,7 +140,7 @@ spec:
         linkInfo = {
             "ticket": ticket_number,
             "title": f"{commit_message} [{codebase}][{vcs_tag}]",
-            "url": pipeline_url
+            "url": git_commit_url
         }
         print("[TEKTON] Issue Link:\n{}".format(json.dumps(linkInfo, indent = 4)))
 


### PR DESCRIPTION
## Description
This pull request updates the configuration and script files to replace the usage of `PIPELINE_URL` with `GIT_WEB_URL`. The changes include:

- Removing `PIPELINE_URL` from the environment variables and YAML configurations.
- Updating the script to use `GIT_WEB_URL` instead of `PIPELINE_URL` for generating the issue link.

This change ensures that the Jira issue link now correctly uses the Git commit URL instead of the pipeline URL, aligning with the project requirements.

Fixes # (issue)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How Has This Been Tested?
I tested the changes by running the Tekton task with the updated configuration and verified that the Jira issue link was correctly generated using the `GIT_WEB_URL` and included the commit ID.

## Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] Pull Request contains one commit. I squash my commits.

## Screenshots (if appropriate):