### PR TITLE
chore: Update rpm-build flow for java17 maven (#282)

### DIFF
--- a/charts/pipelines-library/templates/pipelines/java/maven/github-rpm-build-default.yaml
+++ b/charts/pipelines-library/templates/pipelines/java/maven/github-rpm-build-default.yaml
@@ -281,19 +281,18 @@ spec:
         - push
         - build
       params:
-        - name: codebase_name
-          value: "$(params.CODEBASE_NAME)"
         - name: suffix
           value: "$(tasks.get-version.results.NORMALIZED_VERSION)"
         - name: EXTRA_LINT_COMMAND
           value: |
-            make rpm-lint NAME=${CODEBASE_NAME}
+            make rpm-lint
         - name: EXTRA_BUILD_COMMAND
           value: |
-            make rpm-build NAME=${CODEBASE_NAME} RELEASE=${SUFFIX}
+            make rpm-build RELEASE=${SUFFIX}
         - name: EXTRA_PUSH_COMMAND
           value: |
-            make publish NAME=${CODEBASE_NAME} RELEASE=${SUFFIX} CI_USERNAME=${CI_USERNAME} CI_PASSWORD=${CI_PASSWORD} NEXUS_HOST_URL=${NEXUS_HOST_URL}
+            make rpm-publish RELEASE=${SUFFIX} \
+            CI_USERNAME=${CI_USERNAME} CI_PASSWORD=${CI_PASSWORD} NEXUS_HOST_URL=${NEXUS_HOST_URL}
       workspaces:
         - name: source
           workspace: shared-workspace

--- a/charts/pipelines-library/templates/pipelines/java/maven/github-rpm-build-edp.yaml
+++ b/charts/pipelines-library/templates/pipelines/java/maven/github-rpm-build-edp.yaml
@@ -34,11 +34,11 @@ spec:
       default: ""
       type: string
     - name: image
-      default: 'maven:3.9.0-eclipse-temurin-11'
+      default: 'maven:3.9.0-eclipse-temurin-17'
       description: "maven image version"
       type: string
     - name: sonar_image
-      default: 'maven:3.9.0-eclipse-temurin-11'
+      default: 'maven:3.9.0-eclipse-temurin-17'
       description: "sonar image version"
       type: string
     - name: TICKET_NAME_PATTERN
@@ -279,21 +279,20 @@ spec:
         - push
         - build
       params:
-        - name: codebase_name
-          value: "$(params.CODEBASE_NAME)"
         - name: suffix
           value: "$(tasks.get-version.results.SUFFIX)"
         - name: numeric_version
           value: "$(tasks.get-version.results.NUMERIC_VERSION)"
         - name: EXTRA_LINT_COMMAND
           value: |
-            make rpm-lint NAME=${CODEBASE_NAME}
+            make rpm-lint
         - name: EXTRA_BUILD_COMMAND
-          value: >
-            make rpm-build NAME=${CODEBASE_NAME} VERSION=${NUMERIC_VERSION} RELEASE=${SUFFIX}
+          value: |
+            make rpm-build VERSION=${NUMERIC_VERSION} RELEASE=${SUFFIX}
         - name: EXTRA_PUSH_COMMAND
-          value: >
-            make publish NAME=${CODEBASE_NAME} RELEASE=${SUFFIX} VERSION=${NUMERIC_VERSION} CI_USERNAME=${CI_USERNAME} CI_PASSWORD=${CI_PASSWORD} NEXUS_HOST_URL=${NEXUS_HOST_URL}
+          value: |
+            make rpm-publish RELEASE=${SUFFIX} VERSION=${NUMERIC_VERSION} \
+            CI_USERNAME=${CI_USERNAME} CI_PASSWORD=${CI_PASSWORD} NEXUS_HOST_URL=${NEXUS_HOST_URL}
       workspaces:
         - name: source
           workspace: shared-workspace

--- a/charts/pipelines-library/templates/tasks/edp-rpm.yaml
+++ b/charts/pipelines-library/templates/tasks/edp-rpm.yaml
@@ -8,25 +8,23 @@ metadata:
     tekton.dev/pipelines.minVersion: "0.17.0"
     tekton.dev/categories: Build Tools
     tekton.dev/tags: build-tool
-    tekton.dev/platforms: "linux/amd64,linux/s390x,linux/ppc64le"
+    tekton.dev/platforms: "linux/amd64"
 spec:
+  description: >-
+    This task is used to build rpm artifact
   params:
     - name: PATH_CONTEXT
       type: string
       default: ""
-      description: The path where package.json of the project is defined.
+      description: The path to the context.
     - name: BASE_IMAGE
       type: string
       default: "docker.io/epamedp/tekton-rpm:0.1.4"
-      description: The rpm image you want to use.
+      description: The rpm image. Should contain all necessary tools to build rpm.
     - name: ci-nexus
       type: string
-      description: name of the secret for the Nexus integration
+      description: Name of the secret for the Nexus integration
       default: ci-nexus
-    - name: codebase_name
-      type: string
-      description: Codebase name of application
-      default: c
     - name: numeric_version
       type: string
       description: Current numeric version of application
@@ -40,16 +38,13 @@ spec:
       description: The path to the cache directory.
     - name: EXTRA_LINT_COMMAND
       type: string
-      description: q
-      default: ""
+      description: Run rpm lint command
     - name: EXTRA_BUILD_COMMAND
       type: string
-      description: q
-      default: ""
+      description: Run rpm build command
     - name: EXTRA_PUSH_COMMAND
       type: string
-      description: q
-      default: ""
+      description: Publish rpm artifact
 
   workspaces:
     - name: source
@@ -57,9 +52,6 @@ spec:
     - name: lint
       image: $(params.BASE_IMAGE)
       workingDir: $(workspaces.source.path)/$(params.PATH_CONTEXT)
-      env:
-        - name: CODEBASE_NAME
-          value: $(params.codebase_name)
       script: |
         set -e
 
@@ -69,8 +61,6 @@ spec:
       image: $(params.BASE_IMAGE)
       workingDir: $(workspaces.source.path)/$(params.PATH_CONTEXT)
       env:
-        - name: CODEBASE_NAME
-          value: $(params.codebase_name)
         - name: NUMERIC_VERSION
           value: $(params.numeric_version)
         - name: SUFFIX
@@ -84,8 +74,6 @@ spec:
       image: $(params.BASE_IMAGE)
       workingDir: $(workspaces.source.path)/$(params.PATH_CONTEXT)
       env:
-        - name: CODEBASE_NAME
-          value: $(params.codebase_name)
         - name: NUMERIC_VERSION
           value: $(params.numeric_version)
         - name: SUFFIX
@@ -107,6 +95,7 @@ spec:
               key: url
       script: |
         set -e
+
         $(params.EXTRA_PUSH_COMMAND)
 
 {{- include "resources" . | nindent 6 }}


### PR DESCRIPTION
This Pull Request introduces a new feature to implement a review and build pipeline that supports RPM for Java and Maven across all Java versions. The necessity for such a feature was identified in the related GitHub issue and aims to streamline the development process by offering better integration with various Git servers.

Related issue #282 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## How Has This Been Tested?
The changes have been tested by creating a mock project that utilizes the new pipeline capabilities.
- Automated tests were added to validate the pipeline's functionality with different Java versions.
- Manual tests were conducted on GitLab, GitHub, and Gerrit to ensure seamless integration.

## Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Pull Request contains one commit. I squash my commits.

## Additional context
The development of this feature was guided by the need to support a more diverse set of technologies and platforms within our build and review pipelines, as outlined in the corresponding GitHub issue. This effort marks a significant step towards enhancing our CI/CD capabilities and offering more flexibility to our developers.
