### PR TITLE
chore: Validate 'type' field for QuickLink resources (#304)

### DIFF
--- a/charts/pipelines-library/templates/resources/gitservers/quicklink.yaml
+++ b/charts/pipelines-library/templates/resources/gitservers/quicklink.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     {{- include "edp-tekton.labels" $ | nindent 4 }}
 spec:
-  type: system
+  type: default
   url: "https://{{ dig "quickLink" "host" $server.host $server}}"
   visible: true
   {{- if eq $server.gitProvider "github" }}

--- a/charts/pipelines-library/tests/test_gerrit_integration.py
+++ b/charts/pipelines-library/tests/test_gerrit_integration.py
@@ -73,7 +73,7 @@ gitServers:
     assert 30100 == gitserver["sshPort"]
 
     guicklink = r["quicklink"]["my-gerrit"]["spec"]
-    assert "system" == guicklink["type"]
+    assert "default" == guicklink["type"]
     assert "https://gerrit-external.com" == guicklink["url"]
 
 def test_gerrit_is_enabled_with_custom_port():

--- a/charts/pipelines-library/tests/test_github_integration.py
+++ b/charts/pipelines-library/tests/test_github_integration.py
@@ -60,7 +60,7 @@ gitServers:
     assert "webhookUrl" not in gitserver
 
     guicklink = r["quicklink"]["my-github"]["spec"]
-    assert "system" == guicklink["type"]
+    assert "default" == guicklink["type"]
     assert "https://github.com" == guicklink["url"]
 
 def test_github_build_trigger():

--- a/charts/pipelines-library/tests/test_gitlab_integration.py
+++ b/charts/pipelines-library/tests/test_gitlab_integration.py
@@ -53,7 +53,7 @@ gitServers:
     assert "https://my-custom-ingress-name.example.com" == gitserver["webhookUrl"]
 
     guicklink = r["quicklink"]["my-gitlab"]["spec"]
-    assert "system" == guicklink["type"]
+    assert "default" == guicklink["type"]
     assert "https://gitlab.com" == guicklink["url"]
 
 def test_gitlab_build_trigger():


### PR DESCRIPTION
# Pull Request

## Description
Validated the `type` field for QuickLink resources for gitServers

Fixes #304 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] Pull Request contain one commit. I squash my commits.