### PR TITLE
chore: Update e2e tests for GH, switch to stable version of Tekton

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -55,63 +55,63 @@ jobs:
             ~/go/pkg/mod
           key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
 
-  e2e-tests-129:
-    name: End-to-end tests 1.29
-    needs: [e2e-tests-130]
-    runs-on: ubuntu-20.04
-    strategy:
-      fail-fast: false
-      max-parallel: 1
+  # e2e-tests-129:
+  #   name: End-to-end tests 1.29
+  #   needs: [e2e-tests-130]
+  #   runs-on: ubuntu-20.04
+  #   strategy:
+  #     fail-fast: false
+  #     max-parallel: 1
 
-    steps:
-      - name: Set up Go
-        uses: actions/setup-go@v4
-        with:
-          go-version: ${{ env.GOLANG_VERSION }}
+  #   steps:
+  #     - name: Set up Go
+  #       uses: actions/setup-go@v4
+  #       with:
+  #         go-version: ${{ env.GOLANG_VERSION }}
 
-      - name: Check out code into the Go module directory
-        uses: actions/checkout@v4
+  #     - name: Check out code into the Go module directory
+  #       uses: actions/checkout@v4
 
-      - name: Get cache
-        uses: actions/cache@v3
-        with:
-          path: |
-            ~/.cache/go-build
-            ~/go/pkg/mod
-          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-go-
+  #     - name: Get cache
+  #       uses: actions/cache@v3
+  #       with:
+  #         path: |
+  #           ~/.cache/go-build
+  #           ~/go/pkg/mod
+  #         key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+  #         restore-keys: |
+  #           ${{ runner.os }}-go-
 
-      - name: "install kuttl"
-        run: ./hack/install-kuttl.sh
+  #     - name: "install kuttl"
+  #       run: ./hack/install-kuttl.sh
 
-      - name: "run tests"
-        env:
-          KUBE_VERSION: "1.29"
-        run: make start-kind KUBE_VERSION=$KUBE_VERSION && make e2e
+  #     - name: "run tests"
+  #       env:
+  #         KUBE_VERSION: "1.29"
+  #       run: make start-kind KUBE_VERSION=$KUBE_VERSION && make e2e
 
-      - name: Save cache
-        id: cache-save
-        uses: actions/cache/save@v4
-        with:
-          path: |
-            ~/.cache/go-build
-            ~/go/pkg/mod
-          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+  #     - name: Save cache
+  #       id: cache-save
+  #       uses: actions/cache/save@v4
+  #       with:
+  #         path: |
+  #           ~/.cache/go-build
+  #           ~/go/pkg/mod
+  #         key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
 
-  e2e-tests-check:
-    runs-on: ubuntu-20.04
-    if: always()
-    needs: [e2e-tests-130, e2e-tests-129]
-    steps:
-      - name: Print result
-        run: echo ${{ needs.e2e-tests-130.result }} && echo ${{ needs.e2e-tests-129.result }}
-      - name: Interpret result
-        run: |
-          if [[ success == ${{ needs.e2e-tests-130.result }} && success == ${{ needs.e2e-tests-129.result }} ]]
-          then
-            echo "All matrix jobs passed!"
-          else
-            echo "One or more matrix jobs failed."
-            false
-          fi
+  # e2e-tests-check:
+  #   runs-on: ubuntu-20.04
+  #   if: always()
+  #   needs: [e2e-tests-130, e2e-tests-129]
+  #   steps:
+  #     - name: Print result
+  #       run: echo ${{ needs.e2e-tests-130.result }} && echo ${{ needs.e2e-tests-129.result }}
+  #     - name: Interpret result
+  #       run: |
+  #         if [[ success == ${{ needs.e2e-tests-130.result }} && success == ${{ needs.e2e-tests-129.result }} ]]
+  #         then
+  #           echo "All matrix jobs passed!"
+  #         else
+  #           echo "One or more matrix jobs failed."
+  #           false
+  #         fi

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -189,63 +189,63 @@ jobs:
             ~/go/pkg/mod
           key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
 
-  e2e-tests-129:
-    name: End-to-end tests 1.29
-    needs: [e2e-tests-130]
-    runs-on: ubuntu-20.04
-    strategy:
-      fail-fast: false
-      max-parallel: 1
+  # e2e-tests-129:
+  #   name: End-to-end tests 1.29
+  #   needs: [e2e-tests-130]
+  #   runs-on: ubuntu-20.04
+  #   strategy:
+  #     fail-fast: false
+  #     max-parallel: 1
 
-    steps:
-      - name: Set up Go
-        uses: actions/setup-go@v4
-        with:
-          go-version: ${{ env.GOLANG_VERSION }}
+  #   steps:
+  #     - name: Set up Go
+  #       uses: actions/setup-go@v4
+  #       with:
+  #         go-version: ${{ env.GOLANG_VERSION }}
 
-      - name: Check out code into the Go module directory
-        uses: actions/checkout@v4
+  #     - name: Check out code into the Go module directory
+  #       uses: actions/checkout@v4
 
-      - name: Get cache
-        uses: actions/cache@v3
-        with:
-          path: |
-            ~/.cache/go-build
-            ~/go/pkg/mod
-          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-go-
+  #     - name: Get cache
+  #       uses: actions/cache@v3
+  #       with:
+  #         path: |
+  #           ~/.cache/go-build
+  #           ~/go/pkg/mod
+  #         key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+  #         restore-keys: |
+  #           ${{ runner.os }}-go-
 
-      - name: "install kuttl"
-        run: ./hack/install-kuttl.sh
+  #     - name: "install kuttl"
+  #       run: ./hack/install-kuttl.sh
 
-      - name: "run tests"
-        env:
-          KUBE_VERSION: "1.29"
-        run: make start-kind KUBE_VERSION=$KUBE_VERSION && make e2e
+  #     - name: "run tests"
+  #       env:
+  #         KUBE_VERSION: "1.29"
+  #       run: make start-kind KUBE_VERSION=$KUBE_VERSION && make e2e
 
-      - name: Save cache
-        id: cache-save
-        uses: actions/cache/save@v4
-        with:
-          path: |
-            ~/.cache/go-build
-            ~/go/pkg/mod
-          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+  #     - name: Save cache
+  #       id: cache-save
+  #       uses: actions/cache/save@v4
+  #       with:
+  #         path: |
+  #           ~/.cache/go-build
+  #           ~/go/pkg/mod
+  #         key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
 
-  e2e-tests-check:
-    runs-on: ubuntu-20.04
-    if: always()
-    needs: [e2e-tests-130, e2e-tests-129]
-    steps:
-      - name: Print result
-        run: echo ${{ needs.e2e-tests-130.result }} && echo ${{ needs.e2e-tests-129.result }}
-      - name: Interpret result
-        run: |
-          if [[ success == ${{ needs.e2e-tests-130.result }} && success == ${{ needs.e2e-tests-129.result }} ]]
-          then
-            echo "All matrix jobs passed!"
-          else
-            echo "One or more matrix jobs failed."
-            false
-          fi
+  # e2e-tests-check:
+  #   runs-on: ubuntu-20.04
+  #   if: always()
+  #   needs: [e2e-tests-130, e2e-tests-129]
+  #   steps:
+  #     - name: Print result
+  #       run: echo ${{ needs.e2e-tests-130.result }} && echo ${{ needs.e2e-tests-129.result }}
+  #     - name: Interpret result
+  #       run: |
+  #         if [[ success == ${{ needs.e2e-tests-130.result }} && success == ${{ needs.e2e-tests-129.result }} ]]
+  #         then
+  #           echo "All matrix jobs passed!"
+  #         else
+  #           echo "One or more matrix jobs failed."
+  #           false
+  #         fi

--- a/kuttl-test.yaml
+++ b/kuttl-test.yaml
@@ -20,17 +20,17 @@ commands:
     namespaced: false
   - command: kubectl create ns tekton-pipelines-resolvers
     namespaced: false
-  - command: kubectl apply -f https://storage.googleapis.com/tekton-releases/pipeline/latest/release.yaml
+  - command: kubectl apply -f https://storage.googleapis.com/tekton-releases/pipeline/previous/v0.53.6/release.yaml
     namespaced: false
   # wait for webhooks to be ready
   - command: sleep 60
     namespaced: false
-  - command: kubectl apply -f https://storage.googleapis.com/tekton-releases/triggers/latest/release.yaml
+  - command: kubectl apply -f https://storage.googleapis.com/tekton-releases/triggers/previous/v0.25.3/release.yaml
     namespaced: false
   # wait for webhooks to be ready
   - command: sleep 60
     namespaced: false
-  - command: kubectl apply -f https://storage.googleapis.com/tekton-releases/triggers/latest/interceptors.yaml
+  - command: kubectl apply -f https://storage.googleapis.com/tekton-releases/triggers/previous/v0.25.3/interceptors.yaml
     namespaced: false
   - command: helm repo add epamedp https://epam.github.io/edp-helm-charts/stable
     namespaced: true

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -2,4 +2,4 @@ sonar.projectKey=edp-tekton
 sonar.projectName=edp-tekton
 sonar.go.coverage.reportPaths=coverage.out
 sonar.test.inclusions=**/*_test.go
-sonar.exclusions=*/cache/**,**/config/**,**/deploy-templates/**,**/charts/**,**/cmd/**,**/tests/**,**/hack/**
+sonar.exclusions=*/cache/**,**/config/**,**/deploy-templates/**,**/charts/**,**/cmd/**,**/tests/**,**/hack/**,kuttl-test.yaml


### PR DESCRIPTION
Keep 1.30 version of kubernetes
Set production used version of Tekton