### PR TITLE
feat: Add support kubeconfig in clean pipeline(#350)

### DIFF
--- a/charts/pipelines-library/templates/pipelines/cd/clean.yaml
+++ b/charts/pipelines-library/templates/pipelines/cd/clean.yaml
@@ -21,13 +21,45 @@ spec:
       description: |
         EDP kind:Stage name of the kind:CDPipeline defined in the CDPIPELINE values. For example: dev, test, prod
       type: string
+    - name: KUBECONFIG_SECRET_NAME
+      description: The name of secret with Kubeconfig to connect to the remote cluster
   tasks:
+    - name: pre-clean
+      taskRef:
+        kind: Task
+        name: run-clean-gate
+      params:
+        - name: KUBECONFIG_SECRET_NAME
+          value: $(params.KUBECONFIG_SECRET_NAME)
+        - name: BASE_IMAGE
+          value: "bitnami/kubectl:1.25.4"
+        - name: EXTRA_COMMANDS
+          value:
+            echo "Hello World"
+
     - name: clean
       taskRef:
         kind: Task
         name: clean
+      runAfter:
+        - pre-clean
       params:
         - name: PIPELINE
           value: $(params.CDPIPELINE)
         - name: STAGE
           value: $(params.CDSTAGE)
+
+    - name: post-clean
+      taskRef:
+        kind: Task
+        name: run-clean-gate
+      runAfter:
+        - clean
+      params:
+        - name: KUBECONFIG_SECRET_NAME
+          value: $(params.KUBECONFIG_SECRET_NAME)
+        - name: BASE_IMAGE
+          value: "bitnami/kubectl:1.25.4"
+        - name: EXTRA_COMMANDS
+          value:
+            echo "Hello World"

--- a/charts/pipelines-library/templates/pipelines/cd/deploy-with-autotests.yaml
+++ b/charts/pipelines-library/templates/pipelines/cd/deploy-with-autotests.yaml
@@ -84,7 +84,7 @@ spec:
           kind: Task
           name: init-autotest
       runAfter:
-         - post-deploy
+        - post-deploy
       params:
         - name: stage-name
           value: $(params.CDSTAGE)
@@ -106,7 +106,7 @@ spec:
           kind: Task
           name: wait-for-autotests
       runAfter:
-         - init-autotest
+        - init-autotest
       params:
         - name: AUTOTEST_PIPELINES
           value: $(params.autotes-pipeline)

--- a/charts/pipelines-library/templates/tasks/run-сleanup-gate.yaml
+++ b/charts/pipelines-library/templates/tasks/run-сleanup-gate.yaml
@@ -1,0 +1,35 @@
+apiVersion: tekton.dev/v1
+kind: Task
+metadata:
+  name: run-clean-gate
+spec:
+  description: >-
+    This task runs a clean gate. It can use a Kubeconfig secret to connect to a remote Kubernetes cluster.
+  volumes:
+    - name: kubeconfig
+      secret:
+        secretName: $(params.KUBECONFIG_SECRET_NAME)
+        optional: true
+  params:
+    - name: BASE_IMAGE
+      description: The base image for the task (different for buildtools).
+      type: string
+      default: ""
+    - name: EXTRA_COMMANDS
+      type: string
+      description: Extra commands
+      default: ""
+    - name: KUBECONFIG_SECRET_NAME
+      type: string
+      description: The name of secret with Kubeconfig to connect to the remote cluster
+      default: "in-cluster"
+  steps:
+    - name: run
+      image: $(params.BASE_IMAGE)
+      volumeMounts:
+        - name: kubeconfig
+          mountPath: /workspace/source/kube
+      script: |
+        set -ex
+        export KUBECONFIG="workspace/source/kube/config"
+        $(params.EXTRA_COMMANDS)

--- a/charts/pipelines-library/templates/triggers/cd/clean.yaml
+++ b/charts/pipelines-library/templates/triggers/cd/clean.yaml
@@ -12,6 +12,8 @@ spec:
     - name: CDSTAGE
       description: |
         EDP kind:Stage name of the kind:CDPipeline defined in the CDPIPELINE values. For example: dev, test, prod
+    - name: KUBECONFIG_SECRET_NAME
+      description: The name of secret with Kubeconfig to connect to the remote cluster
   resourcetemplates:
     - apiVersion: tekton.dev/v1
       kind: PipelineRun
@@ -33,5 +35,7 @@ spec:
             value: $(tt.params.CDSTAGE)
           - name: CDPIPELINE
             value: $(tt.params.CDPIPELINE)
+          - name: KUBECONFIG_SECRET_NAME
+            value: $(tt.params.KUBECONFIG_SECRET_NAME)
         timeouts:
           pipeline: 1h00m0s


### PR DESCRIPTION
## Description

This PR introduces a new cleanup task in the CD pipeline, enhancing the pipeline with pre- and post-cleanup stages. It includes additional parameters for secret configuration and extra commands, which facilitate more customizable cleanup operations across environments. Documentation and code comments have been added for clarity.

## Type of change

- [x] Enhancement (non-breaking change which improves an existing feature or documentation)

## How Has This Been Tested?

The new task has been tested in a developer-stage environment. The application was deployed successfully and cleaned up using the updated pipeline. Verified pipeline behavior and successful cleanup in different test scenarios.

## Checklist:
- [x] I have performed a self-review of my code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Pull Request contains one commit. I squash my commits.
