### PR TITLE
chore: Enable deployment env variables in CD pipelines(#360)

### DIFF
--- a/charts/pipelines-library/templates/pipelines/cd-autotests/autotest.yaml
+++ b/charts/pipelines-library/templates/pipelines/cd-autotests/autotest.yaml
@@ -21,6 +21,8 @@ spec:
       default: "master"
     - name: stage-name
       default: "dev"
+    - name: cd-pipeline-name
+      default: "dev"
     - name: base-image
       default: ""
   tasks:
@@ -48,6 +50,8 @@ spec:
       params:
         - name: base-image
           value: "$(params.base-image)"
+        - name: cd-pipeline-name
+          value: "$(params.cd-pipeline-name)"
         - name: stage-name
           value: "$(params.stage-name)"
       workspaces:

--- a/charts/pipelines-library/templates/pipelines/cd/clean.yaml
+++ b/charts/pipelines-library/templates/pipelines/cd/clean.yaml
@@ -29,10 +29,14 @@ spec:
         kind: Task
         name: run-clean-gate
       params:
+        - name: PIPELINE
+          value: $(params.CDPIPELINE)
+        - name: STAGE
+          value: $(params.CDSTAGE)
         - name: KUBECONFIG_SECRET_NAME
           value: $(params.KUBECONFIG_SECRET_NAME)
         - name: BASE_IMAGE
-          value: "bitnami/kubectl:1.25.4"
+          value: "{{ include "edp-tekton.registry" . }}/bitnami/kubectl:1.25.4"
         - name: EXTRA_COMMANDS
           value:
             echo "Hello World"
@@ -56,10 +60,14 @@ spec:
       runAfter:
         - clean
       params:
+        - name: PIPELINE
+          value: $(params.CDPIPELINE)
+        - name: STAGE
+          value: $(params.CDSTAGE)
         - name: KUBECONFIG_SECRET_NAME
           value: $(params.KUBECONFIG_SECRET_NAME)
         - name: BASE_IMAGE
-          value: "bitnami/kubectl:1.25.4"
+          value: "{{ include "edp-tekton.registry" . }}/bitnami/kubectl:1.25.4"
         - name: EXTRA_COMMANDS
           value:
             echo "Hello World"

--- a/charts/pipelines-library/templates/pipelines/cd/deploy-ansible-awx.yaml
+++ b/charts/pipelines-library/templates/pipelines/cd/deploy-ansible-awx.yaml
@@ -35,6 +35,10 @@ spec:
         kind: Task
         name: run-quality-gate
       params:
+        - name: PIPELINE
+          value: $(params.CDPIPELINE)
+        - name: STAGE
+          value: $(params.CDSTAGE)
         - name: BASE_IMAGE
           value: "{{ include "edp-tekton.registry" . }}/bitnami/kubectl:1.25.4"
         - name: EXTRA_COMMANDS
@@ -62,6 +66,10 @@ spec:
       runAfter:
         - deploy-app
       params:
+        - name: PIPELINE
+          value: $(params.CDPIPELINE)
+        - name: STAGE
+          value: $(params.CDSTAGE)
         - name: BASE_IMAGE
           value: "{{ include "edp-tekton.registry" . }}/bitnami/kubectl:1.25.4"
         - name: EXTRA_COMMANDS
@@ -75,6 +83,10 @@ spec:
       runAfter:
         - post-deploy
       params:
+        - name: PIPELINE
+          value: $(params.CDPIPELINE)
+        - name: STAGE
+          value: $(params.CDSTAGE)
         - name: APPLICATIONS_PAYLOAD
           value: $(params.APPLICATIONS_PAYLOAD)
         - name: CDPIPELINE_STAGE

--- a/charts/pipelines-library/templates/pipelines/cd/deploy-ansible.yaml
+++ b/charts/pipelines-library/templates/pipelines/cd/deploy-ansible.yaml
@@ -31,6 +31,10 @@ spec:
         kind: Task
         name: run-quality-gate
       params:
+        - name: PIPELINE
+          value: $(params.CDPIPELINE)
+        - name: STAGE
+          value: $(params.CDSTAGE)
         - name: BASE_IMAGE
           value: "{{ include "edp-tekton.registry" . }}/bitnami/kubectl:1.25.4"
         - name: EXTRA_COMMANDS
@@ -58,6 +62,10 @@ spec:
       runAfter:
         - deploy-app
       params:
+        - name: PIPELINE
+          value: $(params.CDPIPELINE)
+        - name: STAGE
+          value: $(params.CDSTAGE)
         - name: BASE_IMAGE
           value: "{{ include "edp-tekton.registry" . }}/bitnami/kubectl:1.25.4"
         - name: EXTRA_COMMANDS

--- a/charts/pipelines-library/templates/pipelines/cd/deploy-with-approve.yaml
+++ b/charts/pipelines-library/templates/pipelines/cd/deploy-with-approve.yaml
@@ -36,6 +36,10 @@ spec:
         kind: Task
         name: run-quality-gate
       params:
+        - name: PIPELINE
+          value: $(params.CDPIPELINE)
+        - name: STAGE
+          value: $(params.CDSTAGE)
         - name: KUBECONFIG_SECRET_NAME
           value: $(params.KUBECONFIG_SECRET_NAME)
         - name: BASE_IMAGE

--- a/charts/pipelines-library/templates/pipelines/cd/deploy-with-autotests.yaml
+++ b/charts/pipelines-library/templates/pipelines/cd/deploy-with-autotests.yaml
@@ -42,6 +42,10 @@ spec:
         kind: Task
         name: run-quality-gate
       params:
+        - name: PIPELINE
+          value: $(params.CDPIPELINE)
+        - name: STAGE
+          value: $(params.CDSTAGE)
         - name: KUBECONFIG_SECRET_NAME
           value: $(params.KUBECONFIG_SECRET_NAME)
         - name: BASE_IMAGE
@@ -71,6 +75,10 @@ spec:
       runAfter:
         - deploy-app
       params:
+        - name: PIPELINE
+          value: $(params.CDPIPELINE)
+        - name: STAGE
+          value: $(params.CDSTAGE)
         - name: KUBECONFIG_SECRET_NAME
           value: $(params.KUBECONFIG_SECRET_NAME)
         - name: BASE_IMAGE

--- a/charts/pipelines-library/templates/pipelines/cd/deploy.yaml
+++ b/charts/pipelines-library/templates/pipelines/cd/deploy.yaml
@@ -34,6 +34,10 @@ spec:
         kind: Task
         name: run-quality-gate
       params:
+        - name: PIPELINE
+          value: $(params.CDPIPELINE)
+        - name: STAGE
+          value: $(params.CDSTAGE)
         - name: KUBECONFIG_SECRET_NAME
           value: $(params.KUBECONFIG_SECRET_NAME)
         - name: BASE_IMAGE
@@ -63,6 +67,10 @@ spec:
       runAfter:
         - deploy-app
       params:
+        - name: PIPELINE
+          value: $(params.CDPIPELINE)
+        - name: STAGE
+          value: $(params.CDSTAGE)
         - name: KUBECONFIG_SECRET_NAME
           value: $(params.KUBECONFIG_SECRET_NAME)
         - name: BASE_IMAGE

--- a/charts/pipelines-library/templates/tasks/autotest-cd-pipeline/init-autotests.yaml
+++ b/charts/pipelines-library/templates/tasks/autotest-cd-pipeline/init-autotests.yaml
@@ -46,7 +46,9 @@ spec:
           value: $(params.cd-pipeline-name)
         - name: PARENT_PIPELINE_NAME
           value: $(params.parent-pipeline-name)
-
+      envFrom:
+        - configMapRef:
+            name: $(params.cd-pipeline-name)-$(params.stage-name)
       script: |
         #!/usr/bin/env python
 
@@ -103,6 +105,7 @@ spec:
             -p git-source-url=" + gitAutotesUrl[count] + " \
             -p git-source-revision=" + autotestsBranch[count] + " \
             -p stage-name=" + stage +" \
+            -p cd-pipeline-name=" + cdPipelineName +" \
             -p base-image=" + frameworks[autotestBuildTool[count] + "-" + autotestFramework[count]] + " \
             --labels app.edp.epam.com/pipeline=" + cdPipelineName + " \
             --labels app.edp.epam.com/stage=" + stage + " \

--- a/charts/pipelines-library/templates/tasks/autotest-cd-pipeline/run-autotests-java.yaml
+++ b/charts/pipelines-library/templates/tasks/autotest-cd-pipeline/run-autotests-java.yaml
@@ -19,6 +19,8 @@ spec:
     - name: source
       description: A workspace that contains the repository.
   params:
+    - name: cd-pipeline-name
+      type: string
     - name: stage-name
       type: string
     - name: base-image
@@ -30,6 +32,11 @@ spec:
       env:
         - name: STAGE_NAME
           value: $(params.stage-name)
+        - name: CD_PIPELINE_NAME
+          value: $(params.cd-pipeline-name)
+      envFrom:
+        - configMapRef:
+            name: $(params.cd-pipeline-name)-$(params.stage-name)
       script: |
         #!/bin/bash
 

--- a/charts/pipelines-library/templates/tasks/cd/clean.yaml
+++ b/charts/pipelines-library/templates/tasks/cd/clean.yaml
@@ -29,6 +29,9 @@ spec:
             secretKeyRef:
               name: ci-argocd
               key: token
+      envFrom:
+        - configMapRef:
+            name: $(params.PIPELINE)-$(params.STAGE)
       script: |
         set -ex
 

--- a/charts/pipelines-library/templates/tasks/cd/deploy-ansible-awx.yaml
+++ b/charts/pipelines-library/templates/tasks/cd/deploy-ansible-awx.yaml
@@ -49,12 +49,15 @@ spec:
             secretKeyRef:
               name: ci-awx
               key: password
+      envFrom:
+        - configMapRef:
+            name: $(params.PIPELINE)-$(params.STAGE)
       script: |
         #!/usr/bin/env sh
 
         set -eu
         tower-cli config host ${AWX_HOST}
-        tower-cli config username ${AWX_USERNAME} 
+        tower-cli config username ${AWX_USERNAME}
         tower-cli config password ${AWX_PASSWORD}
         tower-cli config verify_ssl false
 

--- a/charts/pipelines-library/templates/tasks/cd/deploy-ansible.yaml
+++ b/charts/pipelines-library/templates/tasks/cd/deploy-ansible.yaml
@@ -44,6 +44,9 @@ spec:
             secretKeyRef:
               name: ci-nexus
               key: password
+      envFrom:
+        - configMapRef:
+            name: $(params.PIPELINE)-$(params.STAGE)
       script: |
         #!/usr/bin/env python
         import os

--- a/charts/pipelines-library/templates/tasks/cd/run-quality-gate.yaml
+++ b/charts/pipelines-library/templates/tasks/cd/run-quality-gate.yaml
@@ -1,16 +1,26 @@
 apiVersion: tekton.dev/v1
 kind: Task
 metadata:
-  name: run-clean-gate
+  name: run-quality-gate
 spec:
   description: >-
-    This task runs a clean gate. It can use a Kubeconfig secret to connect to a remote Kubernetes cluster.
+    This task runs a quality gate. It can use a Kubeconfig secret to connect to a remote Kubernetes cluster.
   volumes:
     - name: kubeconfig
       secret:
         secretName: $(params.KUBECONFIG_SECRET_NAME)
         optional: true
   params:
+    - description: >
+        EDP kind:CDPipeline name used for deployment. For example: mypipe,
+        myfeature
+      name: PIPELINE
+      type: string
+    - description: >
+        EDP kind:Stage name of the kind:CDPipeline defined in the CDPIPELINE
+        values. For example: dev, test, prod
+      name: STAGE
+      type: string
     - name: BASE_IMAGE
       description: The base image for the task (different for buildtools).
       type: string
@@ -29,6 +39,9 @@ spec:
       volumeMounts:
         - name: kubeconfig
           mountPath: /workspace/source/kube
+      envFrom:
+        - configMapRef:
+            name: $(params.PIPELINE)-$(params.STAGE)
       script: |
         set -ex
         export KUBECONFIG="workspace/source/kube/config"

--- a/charts/pipelines-library/templates/tasks/cd/run-сleanup-gate.yaml
+++ b/charts/pipelines-library/templates/tasks/cd/run-сleanup-gate.yaml
@@ -1,16 +1,26 @@
 apiVersion: tekton.dev/v1
 kind: Task
 metadata:
-  name: run-quality-gate
+  name: run-clean-gate
 spec:
   description: >-
-    This task runs a quality gate. It can use a Kubeconfig secret to connect to a remote Kubernetes cluster.
+    This task runs a clean gate. It can use a Kubeconfig secret to connect to a remote Kubernetes cluster.
   volumes:
     - name: kubeconfig
       secret:
         secretName: $(params.KUBECONFIG_SECRET_NAME)
         optional: true
   params:
+    - description: >
+        EDP kind:CDPipeline name used for deployment. For example: mypipe,
+        myfeature
+      name: PIPELINE
+      type: string
+    - description: >
+        EDP kind:Stage name of the kind:CDPipeline defined in the CDPIPELINE
+        values. For example: dev, test, prod
+      name: STAGE
+      type: string
     - name: BASE_IMAGE
       description: The base image for the task (different for buildtools).
       type: string
@@ -29,6 +39,9 @@ spec:
       volumeMounts:
         - name: kubeconfig
           mountPath: /workspace/source/kube
+      envFrom:
+        - configMapRef:
+            name: $(params.PIPELINE)-$(params.STAGE)
       script: |
         set -ex
         export KUBECONFIG="workspace/source/kube/config"


### PR DESCRIPTION
## Description
This enhancement allows all stages in the CD pipeline to access and use custom variables defined within their stage configurations, ensuring consistency across the pipeline. Additionally, autotest stages can now leverage these custom variables from their corresponding stage configurations, improving flexibility and customization in testing.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Enhancement (non-breaking change which improves an existing feature or documentation)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## How Has This Been Tested?
This change was deployed in a development environment where the CD pipelines and all associated stages were executed. Each stage was verified to confirm it could access and use the specified custom variables as intended.

## Checklist:
- [x] I have performed a self-review of my code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Pull Request contains one commit. I squash my commits.