### PR TITLE
chore: Bump gradle image version(#369)

### DIFF
--- a/charts/pipelines-library/templates/_helpers.tpl
+++ b/charts/pipelines-library/templates/_helpers.tpl
@@ -102,13 +102,13 @@ Define registry for pipelines images
 {{- $gradleVersions := dict -}}
 {{- with .Values.pipelines.deployableResources.java -}}
   {{- if .java8 }}
-    {{- $gradleVersions = set $gradleVersions "java8" (printf "%s/gradle:7.5.1-jdk8" $registry)  }}
+    {{- $gradleVersions = set $gradleVersions "java8" (printf "%s/gradle:7.6.1-jdk8" $registry)  }}
   {{- end }}
   {{- if .java11 }}
-    {{- $gradleVersions = set $gradleVersions "java11" (printf "%s/gradle:7.5.1-jdk11" $registry)  }}
+    {{- $gradleVersions = set $gradleVersions "java11" (printf "%s/gradle:7.6.1-jdk11" $registry)  }}
   {{- end }}
   {{- if .java17 }}
-    {{- $gradleVersions = set $gradleVersions "java17" (printf "%s/gradle:7.5.1-jdk17" $registry)  }}
+    {{- $gradleVersions = set $gradleVersions "java17" (printf "%s/gradle:7.6.1-jdk17" $registry)  }}
   {{- end }}
 {{- end }}
 {{- $gradleVersions | toYaml -}}
@@ -119,13 +119,13 @@ Define registry for pipelines images
 {{- $sonarVersions := dict -}}
 {{- with .Values.pipelines.deployableResources.java -}}
   {{- if .java8 }}
-    {{- $sonarVersions = set $sonarVersions "java8" (printf "%s/gradle:7.5.1-jdk11" $registry) }}
+    {{- $sonarVersions = set $sonarVersions "java8" (printf "%s/gradle:7.6.1-jdk11" $registry) }}
   {{- end }}
   {{- if .java11 }}
-    {{- $sonarVersions = set $sonarVersions "java11" (printf "%sgradle:7.5.1-jdk11" $registry) }}
+    {{- $sonarVersions = set $sonarVersions "java11" (printf "%sgradle:7.6.1-jdk11" $registry) }}
   {{- end }}
   {{- if .java17 }}
-    {{- $sonarVersions = set $sonarVersions "java17" (printf "%s/gradle:7.5.1-jdk17" $registry) }}
+    {{- $sonarVersions = set $sonarVersions "java17" (printf "%s/gradle:7.6.1-jdk17" $registry) }}
   {{- end }}
 {{- end }}
 {{- $sonarVersions | toYaml -}}

--- a/charts/pipelines-library/templates/pipelines/groovy/bitbucket-build-lib-default.yaml
+++ b/charts/pipelines-library/templates/pipelines/groovy/bitbucket-build-lib-default.yaml
@@ -36,7 +36,7 @@ spec:
       default: ""
       type: string
     - name: image
-      default: '{{ include "edp-tekton.registry" . }}/gradle:7.5.1-jdk11'
+      default: '{{ include "edp-tekton.registry" . }}/gradle:7.6.1-jdk11'
       description: "gradle image version"
       type: string
     - name: TICKET_NAME_PATTERN

--- a/charts/pipelines-library/templates/pipelines/groovy/bitbucket-build-lib-edp.yaml
+++ b/charts/pipelines-library/templates/pipelines/groovy/bitbucket-build-lib-edp.yaml
@@ -36,7 +36,7 @@ spec:
       default: ""
       type: string
     - name: image
-      default: '{{ include "edp-tekton.registry" . }}/gradle:7.5.1-jdk11'
+      default: '{{ include "edp-tekton.registry" . }}/gradle:7.6.1-jdk11'
       description: "gradle image version"
       type: string
     - name: TICKET_NAME_PATTERN

--- a/charts/pipelines-library/templates/pipelines/groovy/bitbucket-review-lib.yaml
+++ b/charts/pipelines-library/templates/pipelines/groovy/bitbucket-review-lib.yaml
@@ -40,7 +40,7 @@ spec:
       description: "Codebasebranch name"
       type: string
     - name: image
-      default: '{{ include "edp-tekton.registry" . }}/gradle:7.5.1-jdk11'
+      default: '{{ include "edp-tekton.registry" . }}/gradle:7.6.1-jdk11'
       description: "gradle image version"
       type: string
     - name: gitfullrepositoryname

--- a/charts/pipelines-library/templates/pipelines/groovy/gerrit-build-lib-default.yaml
+++ b/charts/pipelines-library/templates/pipelines/groovy/gerrit-build-lib-default.yaml
@@ -32,7 +32,7 @@ spec:
       description: "Codebasebranch name"
       type: string
     - name: image
-      default: '{{ include "edp-tekton.registry" . }}/gradle:7.5.1-jdk11'
+      default: '{{ include "edp-tekton.registry" . }}/gradle:7.6.1-jdk11'
       description: "gradle image version"
       type: string
     - name: changeNumber

--- a/charts/pipelines-library/templates/pipelines/groovy/gerrit-build-lib-edp.yaml
+++ b/charts/pipelines-library/templates/pipelines/groovy/gerrit-build-lib-edp.yaml
@@ -33,7 +33,7 @@ spec:
       description: "Codebasebranch name"
       type: string
     - name: image
-      default: '{{ $registry }}/gradle:7.5.1-jdk11'
+      default: '{{ $registry }}/gradle:7.6.1-jdk11'
       description: "gradle image version"
       type: string
     - name: changeNumber

--- a/charts/pipelines-library/templates/pipelines/groovy/gerrit-review-lib.yaml
+++ b/charts/pipelines-library/templates/pipelines/groovy/gerrit-review-lib.yaml
@@ -33,7 +33,7 @@ spec:
       description: "Project name"
       type: string
     - name: image
-      default: '{{ include "edp-tekton.registry" . }}/gradle:7.5.1-jdk11'
+      default: '{{ include "edp-tekton.registry" . }}/gradle:7.6.1-jdk11'
       description: "gradle image version"
       type: string
     - name: targetBranch

--- a/charts/pipelines-library/templates/pipelines/groovy/github-build-lib-default.yaml
+++ b/charts/pipelines-library/templates/pipelines/groovy/github-build-lib-default.yaml
@@ -37,7 +37,7 @@ spec:
       default: ""
       type: string
     - name: image
-      default: '{{ $registry }}/gradle:7.5.1-jdk11'
+      default: '{{ $registry }}/gradle:7.6.1-jdk11'
       description: "gradle image version"
       type: string
     - name: TICKET_NAME_PATTERN

--- a/charts/pipelines-library/templates/pipelines/groovy/github-build-lib-edp.yaml
+++ b/charts/pipelines-library/templates/pipelines/groovy/github-build-lib-edp.yaml
@@ -36,7 +36,7 @@ spec:
       default: ""
       type: string
     - name: image
-      default: '{{ include "edp-tekton.registry" . }}/gradle:7.5.1-jdk11'
+      default: '{{ include "edp-tekton.registry" . }}/gradle:7.6.1-jdk11'
       description: "gradle image version"
       type: string
     - name: TICKET_NAME_PATTERN

--- a/charts/pipelines-library/templates/pipelines/groovy/github-review-lib.yaml
+++ b/charts/pipelines-library/templates/pipelines/groovy/github-review-lib.yaml
@@ -40,7 +40,7 @@ spec:
       description: "Codebasebranch name"
       type: string
     - name: image
-      default: '{{ include "edp-tekton.registry" . }}/gradle:7.5.1-jdk11'
+      default: '{{ include "edp-tekton.registry" . }}/gradle:7.6.1-jdk11'
       description: "gradle image version"
       type: string
     - name: gitfullrepositoryname

--- a/charts/pipelines-library/templates/pipelines/groovy/gitlab-build-lib-default.yaml
+++ b/charts/pipelines-library/templates/pipelines/groovy/gitlab-build-lib-default.yaml
@@ -36,7 +36,7 @@ spec:
       default: ""
       type: string
     - name: image
-      default: '{{ include "edp-tekton.registry" . }}/gradle:7.5.1-jdk11'
+      default: '{{ include "edp-tekton.registry" . }}/gradle:7.6.1-jdk11'
       description: "gradle image version"
       type: string
     - name: TICKET_NAME_PATTERN

--- a/charts/pipelines-library/templates/pipelines/groovy/gitlab-build-lib-edp.yaml
+++ b/charts/pipelines-library/templates/pipelines/groovy/gitlab-build-lib-edp.yaml
@@ -36,7 +36,7 @@ spec:
       default: ""
       type: string
     - name: image
-      default: '{{ include "edp-tekton.registry" . }}/gradle:7.5.1-jdk11'
+      default: '{{ include "edp-tekton.registry" . }}/gradle:7.6.1-jdk11'
       description: "gradle image version"
       type: string
     - name: TICKET_NAME_PATTERN

--- a/charts/pipelines-library/templates/pipelines/groovy/gitlab-review-lib.yaml
+++ b/charts/pipelines-library/templates/pipelines/groovy/gitlab-review-lib.yaml
@@ -40,7 +40,7 @@ spec:
       description: "Codebasebranch name"
       type: string
     - name: image
-      default: '{{ include "edp-tekton.registry" . }}/gradle:7.5.1-jdk11'
+      default: '{{ include "edp-tekton.registry" . }}/gradle:7.6.1-jdk11'
       description: "gradle image version"
       type: string
     - name: gitfullrepositoryname

--- a/charts/pipelines-library/templates/tasks/autotest-cd-pipeline/init-autotests.yaml
+++ b/charts/pipelines-library/templates/tasks/autotest-cd-pipeline/init-autotests.yaml
@@ -73,9 +73,9 @@ spec:
         gitSecret = {}
 
         frameworks = {
-          "gradle-java8": "gradle:7.5.1-jdk8",
-          "gradle-java11": "gradle:7.5.1-jdk11",
-          "gradle-java17": "gradle:7.5.1-jdk17",
+          "gradle-java8": "gradle:7.6.1-jdk8",
+          "gradle-java11": "gradle:7.6.1-jdk11",
+          "gradle-java17": "gradle:7.6.1-jdk17",
           "maven-java8": "maven:3.9.0-eclipse-temurin-8",
           "maven-java11": "maven:3.9.0-eclipse-temurin-11",
           "maven-java17": "maven:3.9.0-eclipse-temurin-17"

--- a/charts/pipelines-library/templates/tasks/codenarc.yaml
+++ b/charts/pipelines-library/templates/tasks/codenarc.yaml
@@ -29,7 +29,7 @@ spec:
     - name: BASE_IMAGE
       description: Gradle base image.
       type: string
-      default: {{ include "edp-tekton.registry" . }}/gradle:7.5.1-jdk11
+      default: {{ include "edp-tekton.registry" . }}/gradle:7.6.1-jdk11
     - name: PROJECT_DIR
       description: The directory containing build.gradle
       type: string

--- a/charts/pipelines-library/templates/tasks/edp-gradle.yaml
+++ b/charts/pipelines-library/templates/tasks/edp-gradle.yaml
@@ -25,7 +25,7 @@ spec:
     - name: BASE_IMAGE
       description: Gradle base image.
       type: string
-      default: {{ include "edp-tekton.registry" . }}/gradle:7.5.1-jdk11
+      default: {{ include "edp-tekton.registry" . }}/gradle:7.6.1-jdk11
     - name: PROJECT_DIR
       description: The directory containing build.gradle
       type: string

--- a/charts/pipelines-library/templates/tasks/gradle.yaml
+++ b/charts/pipelines-library/templates/tasks/gradle.yaml
@@ -25,7 +25,7 @@ spec:
     - name: BASE_IMAGE
       description: Gradle base image.
       type: string
-      default: {{ include "edp-tekton.registry" . }}/gradle:7.5.1-jdk11
+      default: {{ include "edp-tekton.registry" . }}/gradle:7.6.1-jdk11
     - name: PROJECT_DIR
       description: The directory containing build.gradle
       type: string

--- a/charts/pipelines-library/templates/tasks/sonar/sonarqube-gradle.yaml
+++ b/charts/pipelines-library/templates/tasks/sonar/sonarqube-gradle.yaml
@@ -62,7 +62,7 @@ spec:
     - name: BASE_IMAGE
       description: Gradle base image.
       type: string
-      default: {{ include "edp-tekton.registry" . }}/gradle:7.5.1-jdk11
+      default: {{ include "edp-tekton.registry" . }}/gradle:7.6.1-jdk11
     - name: PROJECT_DIR
       description: The directory containing build.gradle
       type: string

--- a/hack/images/images.txt
+++ b/hack/images/images.txt
@@ -18,9 +18,9 @@ docker.io/epamedp/tekton-python-make:0.1.7
 docker.io/epamedp/tekton-rpm:0.1.4
 docker.io/epamedp/tekton-tfenv:0.1.4
 docker.io/golang:1.22-bookworm
-docker.io/gradle:7.5.1-jdk11
-docker.io/gradle:7.5.1-jdk17
-docker.io/gradle:7.5.1-jdk8
+docker.io/gradle:7.6.1-jdk11
+docker.io/gradle:7.6.1-jdk17
+docker.io/gradle:7.6.1-jdk8
 docker.io/hadolint/hadolint:v2.10.0-alpine
 docker.io/jnorwood/helm-docs:v1.13.1
 docker.io/library/node:18.20.3-alpine3.20


### PR DESCRIPTION
 All references to the Gradle image in the edp-tekton project have been updated to version gradle:7.6.1-jdk17.
 The functionality of the project was tested in a test environment to ensure operability after the update.
 Issues related to the new image version, if any, were identified and resolved.

Type of change
- [x] Enhancement (non-breaking change which improves an existing feature or documentation)

How Has This Been Tested?

 Testing was performed on a test environment.
 Verified that all project functions work correctly with the updated Gradle image (gradle:7.6.1-jdkXX).
 Ensured no regressions or new issues were introduced by the update.

 Deploy the updated resources to the test environment.
 Test the main functions of the project.
 Validate that the project operates as expected with no errors.

Checklist:
- [x] I have performed a self-review of my code.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] Pull Request contains one commit. I squash my commits.
