### PR TITLE
fix: Sonar image name resource mapping in pipelines(#375)

### DIFF
--- a/charts/pipelines-library/templates/pipelines/autotests/gradle/bitbucket-build-default.yaml
+++ b/charts/pipelines-library/templates/pipelines/autotests/gradle/bitbucket-build-default.yaml
@@ -1,7 +1,7 @@
 {{ if has "bitbucket" .Values.global.gitProviders }}
 {{ if or ( .Values.pipelines.deployableResources.java.java8 ) ( .Values.pipelines.deployableResources.java.java11 ) ( .Values.pipelines.deployableResources.java.java17 )}}
 {{- $raw := include "edp-tekton.resourceMapping.maven" . | fromYaml -}}
-{{- $rawSonar := include "edp-tekton.resourceMapping.mavenSonar" . | fromYaml -}}
+{{- $rawSonar := include "edp-tekton.resourceMapping.gradleSonar" . | fromYaml -}}
 {{- range $framework, $image := $raw }}
 {{- $sonarImage := pluck $framework $rawSonar | first -}}
 apiVersion: tekton.dev/v1

--- a/charts/pipelines-library/templates/pipelines/autotests/gradle/bitbucket-build-edp.yaml
+++ b/charts/pipelines-library/templates/pipelines/autotests/gradle/bitbucket-build-edp.yaml
@@ -1,7 +1,7 @@
 {{ if has "bitbucket" .Values.global.gitProviders }}
 {{ if or ( .Values.pipelines.deployableResources.java.java8 ) ( .Values.pipelines.deployableResources.java.java11 ) ( .Values.pipelines.deployableResources.java.java17 )}}
 {{- $raw := include "edp-tekton.resourceMapping.maven" . | fromYaml -}}
-{{- $rawSonar := include "edp-tekton.resourceMapping.mavenSonar" . | fromYaml -}}
+{{- $rawSonar := include "edp-tekton.resourceMapping.gradleSonar" . | fromYaml -}}
 {{- range $framework, $image := $raw }}
 {{- $sonarImage := pluck $framework $rawSonar | first -}}
 apiVersion: tekton.dev/v1

--- a/charts/pipelines-library/templates/pipelines/autotests/gradle/bitbucket-review.yaml
+++ b/charts/pipelines-library/templates/pipelines/autotests/gradle/bitbucket-review.yaml
@@ -1,7 +1,7 @@
 {{ if has "bitbucket" .Values.global.gitProviders }}
 {{ if or ( .Values.pipelines.deployableResources.java.java8 ) ( .Values.pipelines.deployableResources.java.java11 ) ( .Values.pipelines.deployableResources.java.java17 )}}
 {{- $raw := include "edp-tekton.resourceMapping.maven" . | fromYaml -}}
-{{- $rawSonar := include "edp-tekton.resourceMapping.mavenSonar" . | fromYaml -}}
+{{- $rawSonar := include "edp-tekton.resourceMapping.gradleSonar" . | fromYaml -}}
 {{- range $framework, $image := $raw }}
 {{- $sonarImage := pluck $framework $rawSonar | first -}}
 apiVersion: tekton.dev/v1

--- a/charts/pipelines-library/templates/pipelines/autotests/gradle/gerrit-build-default.yaml
+++ b/charts/pipelines-library/templates/pipelines/autotests/gradle/gerrit-build-default.yaml
@@ -1,7 +1,7 @@
 {{ if has "gerrit" .Values.global.gitProviders }}
 {{ if or ( .Values.pipelines.deployableResources.java.java8 ) ( .Values.pipelines.deployableResources.java.java11 ) ( .Values.pipelines.deployableResources.java.java17 )}}
 {{- $raw := include "edp-tekton.resourceMapping.maven" . | fromYaml -}}
-{{- $rawSonar := include "edp-tekton.resourceMapping.mavenSonar" . | fromYaml -}}
+{{- $rawSonar := include "edp-tekton.resourceMapping.gradleSonar" . | fromYaml -}}
 {{- range $framework, $image := $raw }}
 {{- $sonarImage := pluck $framework $rawSonar | first -}}
 apiVersion: tekton.dev/v1

--- a/charts/pipelines-library/templates/pipelines/autotests/gradle/gerrit-build-edp.yaml
+++ b/charts/pipelines-library/templates/pipelines/autotests/gradle/gerrit-build-edp.yaml
@@ -1,7 +1,7 @@
 {{ if has "gerrit" .Values.global.gitProviders }}
 {{ if or ( .Values.pipelines.deployableResources.java.java8 ) ( .Values.pipelines.deployableResources.java.java11 ) ( .Values.pipelines.deployableResources.java.java17 )}}
 {{- $raw := include "edp-tekton.resourceMapping.maven" . | fromYaml -}}
-{{- $rawSonar := include "edp-tekton.resourceMapping.mavenSonar" . | fromYaml -}}
+{{- $rawSonar := include "edp-tekton.resourceMapping.gradleSonar" . | fromYaml -}}
 {{- range $framework, $image := $raw }}
 {{- $sonarImage := pluck $framework $rawSonar | first -}}
 apiVersion: tekton.dev/v1

--- a/charts/pipelines-library/templates/pipelines/autotests/gradle/gerrit-review.yaml
+++ b/charts/pipelines-library/templates/pipelines/autotests/gradle/gerrit-review.yaml
@@ -1,7 +1,7 @@
 {{ if has "gerrit" .Values.global.gitProviders }}
 {{ if or ( .Values.pipelines.deployableResources.java.java8 ) ( .Values.pipelines.deployableResources.java.java11 ) ( .Values.pipelines.deployableResources.java.java17 )}}
 {{- $raw := include "edp-tekton.resourceMapping.maven" . | fromYaml -}}
-{{- $rawSonar := include "edp-tekton.resourceMapping.mavenSonar" . | fromYaml -}}
+{{- $rawSonar := include "edp-tekton.resourceMapping.gradleSonar" . | fromYaml -}}
 {{- range $framework, $image := $raw }}
 {{- $sonarImage := pluck $framework $rawSonar | first -}}
 apiVersion: tekton.dev/v1

--- a/charts/pipelines-library/templates/pipelines/autotests/gradle/github-build-default.yaml
+++ b/charts/pipelines-library/templates/pipelines/autotests/gradle/github-build-default.yaml
@@ -1,7 +1,7 @@
 {{ if has "github" .Values.global.gitProviders }}
 {{ if or ( .Values.pipelines.deployableResources.java.java8 ) ( .Values.pipelines.deployableResources.java.java11 ) ( .Values.pipelines.deployableResources.java.java17 )}}
 {{- $raw := include "edp-tekton.resourceMapping.maven" . | fromYaml -}}
-{{- $rawSonar := include "edp-tekton.resourceMapping.mavenSonar" . | fromYaml -}}
+{{- $rawSonar := include "edp-tekton.resourceMapping.gradleSonar" . | fromYaml -}}
 {{- range $framework, $image := $raw }}
 {{- $sonarImage := pluck $framework $rawSonar | first -}}
 apiVersion: tekton.dev/v1

--- a/charts/pipelines-library/templates/pipelines/autotests/gradle/github-build-edp.yaml
+++ b/charts/pipelines-library/templates/pipelines/autotests/gradle/github-build-edp.yaml
@@ -1,7 +1,7 @@
 {{ if has "github" .Values.global.gitProviders }}
 {{ if or ( .Values.pipelines.deployableResources.java.java8 ) ( .Values.pipelines.deployableResources.java.java11 ) ( .Values.pipelines.deployableResources.java.java17 )}}
 {{- $raw := include "edp-tekton.resourceMapping.maven" . | fromYaml -}}
-{{- $rawSonar := include "edp-tekton.resourceMapping.mavenSonar" . | fromYaml -}}
+{{- $rawSonar := include "edp-tekton.resourceMapping.gradleSonar" . | fromYaml -}}
 {{- range $framework, $image := $raw }}
 {{- $sonarImage := pluck $framework $rawSonar | first -}}
 apiVersion: tekton.dev/v1

--- a/charts/pipelines-library/templates/pipelines/autotests/gradle/github-review.yaml
+++ b/charts/pipelines-library/templates/pipelines/autotests/gradle/github-review.yaml
@@ -1,7 +1,7 @@
 {{ if has "github" .Values.global.gitProviders }}
 {{ if or ( .Values.pipelines.deployableResources.java.java8 ) ( .Values.pipelines.deployableResources.java.java11 ) ( .Values.pipelines.deployableResources.java.java17 )}}
 {{- $raw := include "edp-tekton.resourceMapping.maven" . | fromYaml -}}
-{{- $rawSonar := include "edp-tekton.resourceMapping.mavenSonar" . | fromYaml -}}
+{{- $rawSonar := include "edp-tekton.resourceMapping.gradleSonar" . | fromYaml -}}
 {{- range $framework, $image := $raw }}
 {{- $sonarImage := pluck $framework $rawSonar | first -}}
 apiVersion: tekton.dev/v1

--- a/charts/pipelines-library/templates/pipelines/autotests/gradle/gitlab-build-default.yaml
+++ b/charts/pipelines-library/templates/pipelines/autotests/gradle/gitlab-build-default.yaml
@@ -1,7 +1,7 @@
 {{ if has "gitlab" .Values.global.gitProviders }}
 {{ if or ( .Values.pipelines.deployableResources.java.java8 ) ( .Values.pipelines.deployableResources.java.java11 ) ( .Values.pipelines.deployableResources.java.java17 )}}
 {{- $raw := include "edp-tekton.resourceMapping.maven" . | fromYaml -}}
-{{- $rawSonar := include "edp-tekton.resourceMapping.mavenSonar" . | fromYaml -}}
+{{- $rawSonar := include "edp-tekton.resourceMapping.gradleSonar" . | fromYaml -}}
 {{- range $framework, $image := $raw }}
 {{- $sonarImage := pluck $framework $rawSonar | first -}}
 apiVersion: tekton.dev/v1

--- a/charts/pipelines-library/templates/pipelines/autotests/gradle/gitlab-build-edp.yaml
+++ b/charts/pipelines-library/templates/pipelines/autotests/gradle/gitlab-build-edp.yaml
@@ -1,7 +1,7 @@
 {{ if has "gitlab" .Values.global.gitProviders }}
 {{ if or ( .Values.pipelines.deployableResources.java.java8 ) ( .Values.pipelines.deployableResources.java.java11 ) ( .Values.pipelines.deployableResources.java.java17 )}}
 {{- $raw := include "edp-tekton.resourceMapping.maven" . | fromYaml -}}
-{{- $rawSonar := include "edp-tekton.resourceMapping.mavenSonar" . | fromYaml -}}
+{{- $rawSonar := include "edp-tekton.resourceMapping.gradleSonar" . | fromYaml -}}
 {{- range $framework, $image := $raw }}
 {{- $sonarImage := pluck $framework $rawSonar | first -}}
 apiVersion: tekton.dev/v1

--- a/charts/pipelines-library/templates/pipelines/autotests/gradle/gitlab-review.yaml
+++ b/charts/pipelines-library/templates/pipelines/autotests/gradle/gitlab-review.yaml
@@ -1,7 +1,7 @@
 {{ if has "gitlab" .Values.global.gitProviders }}
 {{ if or ( .Values.pipelines.deployableResources.java.java8 ) ( .Values.pipelines.deployableResources.java.java11 ) ( .Values.pipelines.deployableResources.java.java17 )}}
 {{- $raw := include "edp-tekton.resourceMapping.maven" . | fromYaml -}}
-{{- $rawSonar := include "edp-tekton.resourceMapping.mavenSonar" . | fromYaml -}}
+{{- $rawSonar := include "edp-tekton.resourceMapping.gradleSonar" . | fromYaml -}}
 {{- range $framework, $image := $raw }}
 {{- $sonarImage := pluck $framework $rawSonar | first -}}
 apiVersion: tekton.dev/v1


### PR DESCRIPTION
# Pull Request Template

## Description
While executing the Sonar step in Java AUTs (gerrit-gradle-java8-aut, gerrit-gradle-java11-aut, gerrit-gradle-java17-aut), the following error was encountered: '/tekton/scripts/script-1-wljth: line 5: gradle: command not found'. This indicates that the Gradle command is not available in the environment where the script is executed.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
On dev environment.

## Checklist:
- [x] I have performed a self-review of my code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Pull Request contains one commit. I squash my commits.
