### PR TITLE
fix: Align resource mapping(#375)

### DIFF
--- a/charts/pipelines-library/templates/pipelines/js/npm/gitlab-build-edp.yaml
+++ b/charts/pipelines-library/templates/pipelines/js/npm/gitlab-build-edp.yaml
@@ -42,7 +42,7 @@ spec:
       default: ""
       type: string
     - name: image
-      default: '{{ $registry }}}/library/node:18.20.3-alpine3.20'
+      default: '{{ $registry }}/library/node:18.20.3-alpine3.20'
       description: "npm image version"
       type: string
     - name: TICKET_NAME_PATTERN


### PR DESCRIPTION
# Pull Request Template

## Description
During the execution of pipelines for GitLab Git provider, it has been identified that extra symbols within the BaseImage value are causing failures in pulling the TaskRunImage into the pipeline. This issue obstructs the pipeline's ability to proceed with tasks that rely on the TaskRunImage, thereby impacting the efficiency and success rate of the pipeline executions.

Acceptance Criteria:
1. The BaseImage value should not contain any extra, non-essential symbols that could interfere with the parsing or execution processes.
2. The pipeline should successfully pull the TaskRunImage without errors related to the BaseImage value.
3. Pipeline executions involving the TaskRunImage should proceed as expected without being hindered by issues related to the BaseImage value.
4. A verification process should be implemented to ensure that the BaseImage value is validated for format correctness before being used in pipeline executions.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
Local environment 

## Checklist:
- [x] I have performed a self-review of my code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Pull Request contains one commit. I squash my commits.