### PR TITLE
feat: Use label selector for CodebaseImageStream

### DIFF
--- a/charts/common-library/templates/_common.yaml
+++ b/charts/common-library/templates/_common.yaml
@@ -95,8 +95,8 @@
   runAfter:
     - git-tag
   params:
-    - name: CBIS_NAME
-      value: $(tasks.init-values.results.RESULT_IMAGE_NAME)
+    - name: CODEBASEBRANCH_NAME
+      value: $(params.CODEBASEBRANCH_NAME)
     - name: IMAGE_TAG
       value: $(tasks.get-version.results.IS_TAG)
 {{- end -}}
@@ -155,8 +155,8 @@
   runAfter:
     - git-tag
   params:
-    - name: CBIS_NAME
-      value: $(tasks.init-values.results.RESULT_IMAGE_NAME)
+    - name: CODEBASEBRANCH_NAME
+      value: $(params.CODEBASEBRANCH_NAME)
     - name: IMAGE_TAG
       value: "$(tasks.get-version.results.IS_TAG)"
 {{- end -}}

--- a/charts/pipelines-library/templates/pipelines/groovy/bitbucket-build-lib-default.yaml
+++ b/charts/pipelines-library/templates/pipelines/groovy/bitbucket-build-lib-default.yaml
@@ -167,8 +167,8 @@ spec:
       runAfter:
         - git-tag
       params:
-        - name: CBIS_NAME
-          value: $(tasks.init-values.results.RESULT_IMAGE_NAME)
+        - name: CODEBASEBRANCH_NAME
+          value: $(params.CODEBASEBRANCH_NAME)
         - name: IMAGE_TAG
           value: $(tasks.get-version.results.IS_TAG)
 

--- a/charts/pipelines-library/templates/pipelines/groovy/bitbucket-build-lib-edp.yaml
+++ b/charts/pipelines-library/templates/pipelines/groovy/bitbucket-build-lib-edp.yaml
@@ -169,8 +169,8 @@ spec:
       runAfter:
         - git-tag
       params:
-        - name: CBIS_NAME
-          value: $(tasks.init-values.results.RESULT_IMAGE_NAME)
+        - name: CODEBASEBRANCH_NAME
+          value: $(params.CODEBASEBRANCH_NAME)
         - name: IMAGE_TAG
           value: $(tasks.get-version.results.IS_TAG)
 

--- a/charts/pipelines-library/templates/pipelines/groovy/gerrit-build-lib-default.yaml
+++ b/charts/pipelines-library/templates/pipelines/groovy/gerrit-build-lib-default.yaml
@@ -164,8 +164,8 @@ spec:
       runAfter:
         - git-tag
       params:
-        - name: CBIS_NAME
-          value: $(tasks.init-values.results.RESULT_IMAGE_NAME)
+        - name: CODEBASEBRANCH_NAME
+          value: $(params.CODEBASEBRANCH_NAME)
         - name: IMAGE_TAG
           value: $(tasks.get-version.results.IS_TAG)
 

--- a/charts/pipelines-library/templates/pipelines/groovy/gerrit-build-lib-edp.yaml
+++ b/charts/pipelines-library/templates/pipelines/groovy/gerrit-build-lib-edp.yaml
@@ -167,8 +167,8 @@ spec:
       runAfter:
         - git-tag
       params:
-        - name: CBIS_NAME
-          value: $(tasks.init-values.results.RESULT_IMAGE_NAME)
+        - name: CODEBASEBRANCH_NAME
+          value: $(params.CODEBASEBRANCH_NAME)
         - name: IMAGE_TAG
           value: $(tasks.get-version.results.IS_TAG)
 

--- a/charts/pipelines-library/templates/pipelines/groovy/github-build-lib-default.yaml
+++ b/charts/pipelines-library/templates/pipelines/groovy/github-build-lib-default.yaml
@@ -171,8 +171,8 @@ spec:
       runAfter:
         - git-tag
       params:
-        - name: CBIS_NAME
-          value: $(tasks.init-values.results.RESULT_IMAGE_NAME)
+        - name: CODEBASEBRANCH_NAME
+          value: $(params.CODEBASEBRANCH_NAME)
         - name: IMAGE_TAG
           value: $(tasks.get-version.results.IS_TAG)
 

--- a/charts/pipelines-library/templates/pipelines/groovy/github-build-lib-edp.yaml
+++ b/charts/pipelines-library/templates/pipelines/groovy/github-build-lib-edp.yaml
@@ -172,8 +172,8 @@ spec:
       runAfter:
         - git-tag
       params:
-        - name: CBIS_NAME
-          value: $(tasks.init-values.results.RESULT_IMAGE_NAME)
+        - name: CODEBASEBRANCH_NAME
+          value: $(params.CODEBASEBRANCH_NAME)
         - name: IMAGE_TAG
           value: $(tasks.get-version.results.IS_TAG)
 

--- a/charts/pipelines-library/templates/pipelines/groovy/gitlab-build-lib-default.yaml
+++ b/charts/pipelines-library/templates/pipelines/groovy/gitlab-build-lib-default.yaml
@@ -167,8 +167,8 @@ spec:
       runAfter:
         - git-tag
       params:
-        - name: CBIS_NAME
-          value: $(tasks.init-values.results.RESULT_IMAGE_NAME)
+        - name: CODEBASEBRANCH_NAME
+          value: $(params.CODEBASEBRANCH_NAME)
         - name: IMAGE_TAG
           value: $(tasks.get-version.results.IS_TAG)
 

--- a/charts/pipelines-library/templates/pipelines/groovy/gitlab-build-lib-edp.yaml
+++ b/charts/pipelines-library/templates/pipelines/groovy/gitlab-build-lib-edp.yaml
@@ -169,8 +169,8 @@ spec:
       runAfter:
         - git-tag
       params:
-        - name: CBIS_NAME
-          value: $(tasks.init-values.results.RESULT_IMAGE_NAME)
+        - name: CODEBASEBRANCH_NAME
+          value: $(params.CODEBASEBRANCH_NAME)
         - name: IMAGE_TAG
           value: $(tasks.get-version.results.IS_TAG)
 

--- a/charts/pipelines-library/templates/pipelines/helm/bitbucket-build-default.yaml
+++ b/charts/pipelines-library/templates/pipelines/helm/bitbucket-build-default.yaml
@@ -28,6 +28,9 @@ spec:
     - name: CODEBASE_NAME
       description: "Project name"
       type: string
+    - name: CODEBASEBRANCH_NAME
+      description: "Codebasebranch name"
+      type: string
     - name: changeNumber
       description: Change number from Merge Request
       default: ""
@@ -185,8 +188,8 @@ spec:
       runAfter:
         - git-tag
       params:
-        - name: CBIS_NAME
-          value: $(tasks.init-values.results.RESULT_IMAGE_NAME)
+        - name: CODEBASEBRANCH_NAME
+          value: $(params.CODEBASEBRANCH_NAME)
         - name: IMAGE_TAG
           value: $(tasks.get-version.results.VCS_TAG)
 

--- a/charts/pipelines-library/templates/pipelines/helm/bitbucket-build-edp.yaml
+++ b/charts/pipelines-library/templates/pipelines/helm/bitbucket-build-edp.yaml
@@ -198,8 +198,8 @@ spec:
       runAfter:
         - git-tag
       params:
-        - name: CBIS_NAME
-          value: $(tasks.init-values.results.RESULT_IMAGE_NAME)
+        - name: CODEBASEBRANCH_NAME
+          value: $(params.CODEBASEBRANCH_NAME)
         - name: IMAGE_TAG
           value: $(tasks.get-version.results.IS_TAG)
 

--- a/charts/pipelines-library/templates/pipelines/helm/gerrit-build-default.yaml
+++ b/charts/pipelines-library/templates/pipelines/helm/gerrit-build-default.yaml
@@ -32,6 +32,9 @@ spec:
     - name: CODEBASE_NAME
       description: "Project name"
       type: string
+    - name: CODEBASEBRANCH_NAME
+      description: "Codebasebranch name"
+      type: string
     - name: TICKET_NAME_PATTERN
       description: "Ticket name pattern"
       default: ""
@@ -182,8 +185,8 @@ spec:
       runAfter:
         - git-tag
       params:
-        - name: CBIS_NAME
-          value: $(tasks.init-values.results.RESULT_IMAGE_NAME)
+        - name: CODEBASEBRANCH_NAME
+          value: $(params.CODEBASEBRANCH_NAME)
         - name: IMAGE_TAG
           value: $(tasks.get-version.results.VCS_TAG)
 

--- a/charts/pipelines-library/templates/pipelines/helm/gerrit-build-edp.yaml
+++ b/charts/pipelines-library/templates/pipelines/helm/gerrit-build-edp.yaml
@@ -194,8 +194,8 @@ spec:
       runAfter:
         - git-tag
       params:
-        - name: CBIS_NAME
-          value: $(tasks.init-values.results.RESULT_IMAGE_NAME)
+        - name: CODEBASEBRANCH_NAME
+          value: $(params.CODEBASEBRANCH_NAME)
         - name: IMAGE_TAG
           value: $(tasks.get-version.results.IS_TAG)
 

--- a/charts/pipelines-library/templates/pipelines/helm/github-build-default.yaml
+++ b/charts/pipelines-library/templates/pipelines/helm/github-build-default.yaml
@@ -28,6 +28,9 @@ spec:
     - name: CODEBASE_NAME
       description: "Project name"
       type: string
+    - name: CODEBASEBRANCH_NAME
+      description: "Codebasebranch name"
+      type: string
     - name: changeNumber
       description: Change number from Merge Request
       default: ""
@@ -188,8 +191,8 @@ spec:
       runAfter:
         - git-tag
       params:
-        - name: CBIS_NAME
-          value: $(tasks.init-values.results.RESULT_IMAGE_NAME)
+        - name: CODEBASEBRANCH_NAME
+          value: $(params.CODEBASEBRANCH_NAME)
         - name: IMAGE_TAG
           value: $(tasks.get-version.results.VCS_TAG)
 

--- a/charts/pipelines-library/templates/pipelines/helm/github-build-edp.yaml
+++ b/charts/pipelines-library/templates/pipelines/helm/github-build-edp.yaml
@@ -201,8 +201,8 @@ spec:
       runAfter:
         - git-tag
       params:
-        - name: CBIS_NAME
-          value: $(tasks.init-values.results.RESULT_IMAGE_NAME)
+        - name: CODEBASEBRANCH_NAME
+          value: $(params.CODEBASEBRANCH_NAME)
         - name: IMAGE_TAG
           value: $(tasks.get-version.results.IS_TAG)
 

--- a/charts/pipelines-library/templates/pipelines/helm/gitlab-build-default.yaml
+++ b/charts/pipelines-library/templates/pipelines/helm/gitlab-build-default.yaml
@@ -31,6 +31,9 @@ spec:
     - name: CODEBASE_NAME
       description: "Project name"
       type: string
+    - name: CODEBASEBRANCH_NAME
+      description: "Codebasebranch name"
+      type: string
     - name: changeNumber
       description: Change number from Merge Request
       default: ""
@@ -185,8 +188,8 @@ spec:
       runAfter:
         - git-tag
       params:
-        - name: CBIS_NAME
-          value: $(tasks.init-values.results.RESULT_IMAGE_NAME)
+        - name: CODEBASEBRANCH_NAME
+          value: $(params.CODEBASEBRANCH_NAME)
         - name: IMAGE_TAG
           value: $(tasks.get-version.results.VCS_TAG)
 

--- a/charts/pipelines-library/templates/pipelines/helm/gitlab-build-edp.yaml
+++ b/charts/pipelines-library/templates/pipelines/helm/gitlab-build-edp.yaml
@@ -198,8 +198,8 @@ spec:
       runAfter:
         - git-tag
       params:
-        - name: CBIS_NAME
-          value: $(tasks.init-values.results.RESULT_IMAGE_NAME)
+        - name: CODEBASEBRANCH_NAME
+          value: $(params.CODEBASEBRANCH_NAME)
         - name: IMAGE_TAG
           value: $(tasks.get-version.results.IS_TAG)
 

--- a/charts/pipelines-library/templates/tasks/init-values.yaml
+++ b/charts/pipelines-library/templates/tasks/init-values.yaml
@@ -24,8 +24,6 @@ spec:
       description: "edp name"
     - name: NORMALIZED_BRANCH
       description: "Branch name without '/' symbols and lowercase"
-    - name: RESULT_IMAGE_NAME
-      description: "Codebase name with only letters and dashes"
   steps:
     - name: get-values
       image: $(params.BASE_IMAGE)
@@ -43,7 +41,4 @@ spec:
 
         normalizedBranch=$(echo ${BRANCH//[^\(?!.)a-zA-Z0-9]/-} | tr '[:upper:]' '[:lower:]')
         printf "%s" "${normalizedBranch}" > "$(results.NORMALIZED_BRANCH.path)"
-
-        resultImageName="${CODEBASE}-$(echo ${BRANCH//[^a-zA-Z0-9]/-} | tr '[:upper:]' '[:lower:]')"
-        printf "%s" "${resultImageName}" > "$(results.RESULT_IMAGE_NAME.path)"
 {{ end }}

--- a/charts/pipelines-library/templates/tasks/update-cbis.yaml
+++ b/charts/pipelines-library/templates/tasks/update-cbis.yaml
@@ -8,9 +8,9 @@ spec:
     This task updates a Codebase ImageStream (CBIS) with a new image tag. It checks for the presence of tags in the specified CBIS and adds the new tag if it doesn't already exist.
     The task utilizes kubectl commands and is customizable with parameters for CBIS
   params:
-    - name: CBIS_NAME
+    - name: CODEBASEBRANCH_NAME
       type: string
-      description: "Codebase name with only letters and dashes"
+      description: "CodebaseBranch name with only letters and dashes"
     - name: IMAGE_TAG
       type: string
     - name: BASE_IMAGE
@@ -21,26 +21,32 @@ spec:
     - name: update-cbis
       image: $(params.BASE_IMAGE)
       env:
-        - name: CBIS_NAME
-          value: "$(params.CBIS_NAME)"
+        - name: CODEBASEBRANCH_NAME
+          value: "$(params.CODEBASEBRANCH_NAME)"
         - name: IMAGE_TAG
           value: "$(params.IMAGE_TAG)"
       script: |
         #!/usr/bin/env bash
         set -e
 
-        cbisCrTags=$(kubectl get cbis.v2.edp.epam.com ${CBIS_NAME} --output=jsonpath={.spec.tags})
+        cbisName=$(kubectl get cbis.v2.edp.epam.com -l app.edp.epam.com/cbis-codebasebranch="${CODEBASEBRANCH_NAME}" -o jsonpath='{.items[0].metadata.name}')
+        if [ -z "${cbisName}" ]; then
+            echo "[TEKTON][ERROR] No CBIS found with label app.edp.epam.com/cbis-codebasebranch=${CODEBASEBRANCH_NAME}"
+            exit 1
+        fi
+
+        cbisCrTags=$(kubectl get cbis.v2.edp.epam.com ${cbisName} --output=jsonpath={.spec.tags})
         dateFormat=$(date -u '+%Y-%m-%dT%H:%M:%SZ')
         newcbisTag="{\"name\":\"${IMAGE_TAG}\",\"created\":\"${dateFormat}\"}"
 
         if [ "${cbisCrTags}" = "" ] ; then
-            echo "[TEKTON][DEBUG] There're no tags in imageStream ${CBIS_NAME} ... the first one will be added."
-            kubectl patch cbis.v2.edp.epam.com ${CBIS_NAME} --type=merge -p "{\"spec\":{\"tags\":[${newcbisTag}]}}"
+            echo "[TEKTON][DEBUG] There're no tags in imageStream ${cbisName} ... the first one will be added."
+            kubectl patch cbis.v2.edp.epam.com ${cbisName} --type=merge -p "{\"spec\":{\"tags\":[${newcbisTag}]}}"
         fi
 
-        cbisTagsList=$(kubectl get cbis.v2.edp.epam.com ${CBIS_NAME} --output=jsonpath={.spec.tags[*].name})
+        cbisTagsList=$(kubectl get cbis.v2.edp.epam.com ${cbisName} --output=jsonpath={.spec.tags[*].name})
         if [[ ! ${cbisTagsList} == *"${IMAGE_TAG}"* ]]; then
-            echo "[TEKTON][DEBUG] ImageStream ${CBIS_NAME} doesn't contain ${IMAGE_TAG} tag ... it will be added."
-            kubectl patch cbis.v2.edp.epam.com ${CBIS_NAME} --type json -p="[{\"op\": \"add\", \"path\": \"/spec/tags/-\", \"value\": ${newcbisTag} }]"
+            echo "[TEKTON][DEBUG] ImageStream ${cbisName} doesn't contain ${IMAGE_TAG} tag ... it will be added."
+            kubectl patch cbis.v2.edp.epam.com ${cbisName} --type json -p="[{\"op\": \"add\", \"path\": \"/spec/tags/-\", \"value\": ${newcbisTag} }]"
         fi
 {{ end }}


### PR DESCRIPTION
# Pull Request Template

## Description
This change is due to reworking relation between CodebaseBranch and CodebaseImageStream.
epam/edp-codebase-operator#198
The CodebaseImageStream now has a label that allows it to select CodebaseBranch.

Fixes #472

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Enhancement (non-breaking change which improves an existing feature or documentation)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## How Has This Been Tested?
- Manual testing

## Checklist:
- [x] I have performed a self-review of my code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Pull Request contains one commit. I squash my commits.