### PR TITLE
chore: Npm cache reuses instead of downloading dependencies again

### DIFF
--- a/charts/pipelines-library/templates/pipelines/js/npm/antora/bitbucket-build-default.yaml
+++ b/charts/pipelines-library/templates/pipelines/js/npm/antora/bitbucket-build-default.yaml
@@ -116,6 +116,7 @@ spec:
             export npm_config_userconfig=/var/configmap/.npmrc-ci
             export NEXUS_HOST="//${NEXUS_HOST_URL#*://}"
             export NPM_CACHE_DIR=/workspace/source/cache
+            npm cache verify --cache $NPM_CACHE_DIR
             npm ci
             npm run build:prod
       workspaces:

--- a/charts/pipelines-library/templates/pipelines/js/npm/antora/bitbucket-build-edp.yaml
+++ b/charts/pipelines-library/templates/pipelines/js/npm/antora/bitbucket-build-edp.yaml
@@ -116,6 +116,7 @@ spec:
             export npm_config_userconfig=/var/configmap/.npmrc-ci
             export NEXUS_HOST="//${NEXUS_HOST_URL#*://}"
             export NPM_CACHE_DIR=/workspace/source/cache
+            npm cache verify --cache $NPM_CACHE_DIR
             npm ci
             npm run build:prod
       workspaces:

--- a/charts/pipelines-library/templates/pipelines/js/npm/antora/bitbucket-review.yaml
+++ b/charts/pipelines-library/templates/pipelines/js/npm/antora/bitbucket-review.yaml
@@ -123,6 +123,7 @@ spec:
             export npm_config_userconfig=/var/configmap/.npmrc-ci
             export NEXUS_HOST="//${NEXUS_HOST_URL#*://}"
             export NPM_CACHE_DIR=/workspace/source/cache
+            npm cache verify --cache $NPM_CACHE_DIR
             npm ci
             npm run build:prod
       workspaces:

--- a/charts/pipelines-library/templates/pipelines/js/npm/antora/gerrit-build-default.yaml
+++ b/charts/pipelines-library/templates/pipelines/js/npm/antora/gerrit-build-default.yaml
@@ -111,6 +111,7 @@ spec:
             export npm_config_userconfig=/var/configmap/.npmrc-ci
             export NEXUS_HOST="//${NEXUS_HOST_URL#*://}"
             export NPM_CACHE_DIR=/workspace/source/cache
+            npm cache verify --cache $NPM_CACHE_DIR
             npm ci
             npm run build:prod
       workspaces:

--- a/charts/pipelines-library/templates/pipelines/js/npm/antora/gerrit-build-edp.yaml
+++ b/charts/pipelines-library/templates/pipelines/js/npm/antora/gerrit-build-edp.yaml
@@ -111,6 +111,7 @@ spec:
             export npm_config_userconfig=/var/configmap/.npmrc-ci
             export NEXUS_HOST="//${NEXUS_HOST_URL#*://}"
             export NPM_CACHE_DIR=/workspace/source/cache
+            npm cache verify --cache $NPM_CACHE_DIR
             npm ci
             npm run build:prod
       workspaces:

--- a/charts/pipelines-library/templates/pipelines/js/npm/antora/gerrit-review.yaml
+++ b/charts/pipelines-library/templates/pipelines/js/npm/antora/gerrit-review.yaml
@@ -105,6 +105,7 @@ spec:
             export npm_config_userconfig=/var/configmap/.npmrc-ci
             export NEXUS_HOST="//${NEXUS_HOST_URL#*://}"
             export NPM_CACHE_DIR=/workspace/source/cache
+            npm cache verify --cache $NPM_CACHE_DIR
             npm ci
             npm run build:prod
       workspaces:

--- a/charts/pipelines-library/templates/pipelines/js/npm/antora/github-build-default.yaml
+++ b/charts/pipelines-library/templates/pipelines/js/npm/antora/github-build-default.yaml
@@ -117,6 +117,7 @@ spec:
             export npm_config_userconfig=/var/configmap/.npmrc-ci
             export NEXUS_HOST="//${NEXUS_HOST_URL#*://}"
             export NPM_CACHE_DIR=/workspace/source/cache
+            npm cache verify --cache $NPM_CACHE_DIR
             npm ci
             npm run build:prod
       workspaces:

--- a/charts/pipelines-library/templates/pipelines/js/npm/antora/github-build-edp.yaml
+++ b/charts/pipelines-library/templates/pipelines/js/npm/antora/github-build-edp.yaml
@@ -117,6 +117,7 @@ spec:
             export npm_config_userconfig=/var/configmap/.npmrc-ci
             export NEXUS_HOST="//${NEXUS_HOST_URL#*://}"
             export NPM_CACHE_DIR=/workspace/source/cache
+            npm cache verify --cache $NPM_CACHE_DIR
             npm ci
             npm run build:prod
       workspaces:

--- a/charts/pipelines-library/templates/pipelines/js/npm/antora/github-review.yaml
+++ b/charts/pipelines-library/templates/pipelines/js/npm/antora/github-review.yaml
@@ -124,6 +124,7 @@ spec:
             export npm_config_userconfig=/var/configmap/.npmrc-ci
             export NEXUS_HOST="//${NEXUS_HOST_URL#*://}"
             export NPM_CACHE_DIR=/workspace/source/cache
+            npm cache verify --cache $NPM_CACHE_DIR
             npm ci
             npm run build:prod
       workspaces:

--- a/charts/pipelines-library/templates/pipelines/js/npm/antora/gitlab-build-default.yaml
+++ b/charts/pipelines-library/templates/pipelines/js/npm/antora/gitlab-build-default.yaml
@@ -116,6 +116,7 @@ spec:
             export npm_config_userconfig=/var/configmap/.npmrc-ci
             export NEXUS_HOST="//${NEXUS_HOST_URL#*://}"
             export NPM_CACHE_DIR=/workspace/source/cache
+            npm cache verify --cache $NPM_CACHE_DIR
             npm ci
             npm run build:prod
       workspaces:

--- a/charts/pipelines-library/templates/pipelines/js/npm/antora/gitlab-build-edp.yaml
+++ b/charts/pipelines-library/templates/pipelines/js/npm/antora/gitlab-build-edp.yaml
@@ -116,6 +116,7 @@ spec:
             export npm_config_userconfig=/var/configmap/.npmrc-ci
             export NEXUS_HOST="//${NEXUS_HOST_URL#*://}"
             export NPM_CACHE_DIR=/workspace/source/cache
+            npm cache verify --cache $NPM_CACHE_DIR
             npm ci
             npm run build:prod
       workspaces:

--- a/charts/pipelines-library/templates/pipelines/js/npm/antora/gitlab-review.yaml
+++ b/charts/pipelines-library/templates/pipelines/js/npm/antora/gitlab-review.yaml
@@ -123,6 +123,7 @@ spec:
             export npm_config_userconfig=/var/configmap/.npmrc-ci
             export NEXUS_HOST="//${NEXUS_HOST_URL#*://}"
             export NPM_CACHE_DIR=/workspace/source/cache
+            npm cache verify --cache $NPM_CACHE_DIR
             npm ci
             npm run build:prod
       workspaces:

--- a/charts/pipelines-library/templates/tasks/edp-npm.yaml
+++ b/charts/pipelines-library/templates/tasks/edp-npm.yaml
@@ -82,6 +82,7 @@ spec:
         export upBase64=$(echo -n ${CI_USERNAME}:${CI_PASSWORD} | base64)
         export npm_config_userconfig=/var/configmap/.npmrc-ci
         export NEXUS_HOST="//${NEXUS_HOST_URL#*://}"
+        npm cache verify --cache $NPM_CACHE_DIR
         npm ci
 
     - name: build


### PR DESCRIPTION
Description
This PR addresses an issue where the npm cache was not being reused properly during dependency resolution. As a result, redundant downloads occurred on each build, leading to excessively large cache archives that could not be unpacked.
To resolve this, we added a cache verification step using:

bash
```
npm cache verify --cache $NPM_CACHE_DIR
```
This ensures the cache is valid and allows npm to reuse it reliably across builds.

Fixes #734

Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

How Has This Been Tested?
The change has been tested in the CI/CD pipeline where multiple builds were executed using the same cache directory. After adding the npm cache verify step, the cache is consistently reused across builds, and no excessive growth or unpacking failures occur.

To reproduce:

Set up a pipeline using a shared $NPM_CACHE_DIR

Run npm install in multiple builds

Observe cache reuse and verify no unnecessary downloads or cache archive bloating

Checklist:
- [x] I have performed a self-review of my code

- [ ] I have commented on my code, particularly in hard-to-understand areas

- [ ] I have made corresponding changes to the documentation (if applicable)

- [x] My changes generate no new warnings

- [ ] I have added tests that prove my fix is effective or that my feature works (N/A for infra-level cache fix)

- [x] New and existing unit tests pass locally with my changes

- [x] Pull Request contains one commit. I squash my commits.

