### PR TITLE
chore: Make aws_region configMapKeyRef optional (#489)

### DIFF
--- a/charts/pipelines-library/templates/tasks/image-scan-remote.yaml
+++ b/charts/pipelines-library/templates/tasks/image-scan-remote.yaml
@@ -58,6 +58,7 @@ spec:
             configMapKeyRef:
               name: "$(params.krci-config)"
               key: aws_region
+              optional: true
         - name: CONTAINER_REGISTRY_TYPE
           valueFrom:
             configMapKeyRef:


### PR DESCRIPTION
# Pull Request

## Description
Make `aws_region` configMapKeyRef optional in `image-scan-remote` pipeline.

Fixes #489 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Enhancement (non-breaking change which improves an existing feature or documentation)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist:
- [x] I have performed a self-review of my code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] Pull Request contains one commit. I squash my commits.