### PR TITLE
chore: Migrate to bitnamilegacy image repository(#540)

### DIFF
--- a/charts/pipelines-library/README.md
+++ b/charts/pipelines-library/README.md
@@ -130,7 +130,7 @@ Follows [Tekton Interceptor](https://tekton.dev/vault/triggers-main/clusterinter
 | tekton.packageRegistriesSecret.enabled | bool | `false` | Set this as `true` if the secret should be available in Pipelines |
 | tekton.packageRegistriesSecret.name | string | `"package-registries-auth-secret"` | Secret name that will be used in Pipelines. Default: package-registries-auth-secret |
 | tekton.pruner.create | bool | `true` | Specifies whether a cronjob should be created |
-| tekton.pruner.image | string | `"bitnami/kubectl:1.25"` | Docker image to run the pruner, expected to have kubectl and jq |
+| tekton.pruner.image | string | `"bitnamilegacy/kubectl:1.25"` | Docker image to run the pruner, expected to have kubectl and jq |
 | tekton.pruner.imagePullSecrets | list | `[]` | List of ImagePullSecrets to be used by the pruner CronJob |
 | tekton.pruner.resources | object | `{"limits":{"cpu":"100m","memory":"70Mi"},"requests":{"cpu":"50m","memory":"50Mi"}}` | Pod resources for Tekton pruner job |
 | tekton.pruner.schedule | string | `"0 10 */1 * *"` | How often to clean up resources |

--- a/charts/pipelines-library/templates/pipelines/cd/clean.yaml
+++ b/charts/pipelines-library/templates/pipelines/cd/clean.yaml
@@ -38,7 +38,7 @@ spec:
         - name: KUBECONFIG_SECRET_NAME
           value: $(params.KUBECONFIG_SECRET_NAME)
         - name: BASE_IMAGE
-          value: "{{ include "edp-tekton.registry" . }}/bitnami/kubectl:1.25.4"
+          value: "{{ include "edp-tekton.registry" . }}/bitnamilegacy/kubectl:1.25.4"
         - name: EXTRA_COMMANDS
           value:
             echo "Hello World"
@@ -69,7 +69,7 @@ spec:
         - name: KUBECONFIG_SECRET_NAME
           value: $(params.KUBECONFIG_SECRET_NAME)
         - name: BASE_IMAGE
-          value: "{{ include "edp-tekton.registry" . }}/bitnami/kubectl:1.25.4"
+          value: "{{ include "edp-tekton.registry" . }}/bitnamilegacy/kubectl:1.25.4"
         - name: EXTRA_COMMANDS
           value:
             echo "Hello World"

--- a/charts/pipelines-library/templates/pipelines/cd/deploy-ansible-awx.yaml
+++ b/charts/pipelines-library/templates/pipelines/cd/deploy-ansible-awx.yaml
@@ -47,7 +47,7 @@ spec:
         - name: ENVIRONMENT
           value: $(params.CDSTAGE)
         - name: BASE_IMAGE
-          value: "{{ include "edp-tekton.registry" . }}/bitnami/kubectl:1.25.4"
+          value: "{{ include "edp-tekton.registry" . }}/bitnamilegacy/kubectl:1.25.4"
         - name: EXTRA_COMMANDS
           value:
             echo "Hello World"
@@ -78,7 +78,7 @@ spec:
         - name: ENVIRONMENT
           value: $(params.CDSTAGE)
         - name: BASE_IMAGE
-          value: "{{ include "edp-tekton.registry" . }}/bitnami/kubectl:1.25.4"
+          value: "{{ include "edp-tekton.registry" . }}/bitnamilegacy/kubectl:1.25.4"
         - name: EXTRA_COMMANDS
           value:
             echo "Hello World"

--- a/charts/pipelines-library/templates/pipelines/cd/deploy-ansible.yaml
+++ b/charts/pipelines-library/templates/pipelines/cd/deploy-ansible.yaml
@@ -43,7 +43,7 @@ spec:
         - name: ENVIRONMENT
           value: $(params.CDSTAGE)
         - name: BASE_IMAGE
-          value: "{{ include "edp-tekton.registry" . }}/bitnami/kubectl:1.25.4"
+          value: "{{ include "edp-tekton.registry" . }}/bitnamilegacy/kubectl:1.25.4"
         - name: EXTRA_COMMANDS
           value:
             echo "Hello World"
@@ -74,7 +74,7 @@ spec:
         - name: ENVIRONMENT
           value: $(params.CDSTAGE)
         - name: BASE_IMAGE
-          value: "{{ include "edp-tekton.registry" . }}/bitnami/kubectl:1.25.4"
+          value: "{{ include "edp-tekton.registry" . }}/bitnamilegacy/kubectl:1.25.4"
         - name: EXTRA_COMMANDS
           value:
             echo "Hello World"

--- a/charts/pipelines-library/templates/pipelines/cd/deploy-diff-approve.yaml
+++ b/charts/pipelines-library/templates/pipelines/cd/deploy-diff-approve.yaml
@@ -73,7 +73,7 @@ spec:
         - name: KUBECONFIG_SECRET_NAME
           value: $(params.KUBECONFIG_SECRET_NAME)
         - name: BASE_IMAGE
-          value: "{{ include "edp-tekton.registry" . }}/bitnami/kubectl:1.25.4"
+          value: "{{ include "edp-tekton.registry" . }}/bitnamilegacy/kubectl:1.25.4"
         - name: EXTRA_COMMANDS
           value:
             echo "Hello World"
@@ -106,7 +106,7 @@ spec:
         - name: KUBECONFIG_SECRET_NAME
           value: $(params.KUBECONFIG_SECRET_NAME)
         - name: BASE_IMAGE
-          value: "{{ include "edp-tekton.registry" . }}/bitnami/kubectl:1.25.4"
+          value: "{{ include "edp-tekton.registry" . }}/bitnamilegacy/kubectl:1.25.4"
         - name: EXTRA_COMMANDS
           value:
             echo "Hello World"

--- a/charts/pipelines-library/templates/pipelines/cd/deploy-with-approve.yaml
+++ b/charts/pipelines-library/templates/pipelines/cd/deploy-with-approve.yaml
@@ -49,7 +49,7 @@ spec:
         - name: KUBECONFIG_SECRET_NAME
           value: $(params.KUBECONFIG_SECRET_NAME)
         - name: BASE_IMAGE
-          value: "{{ include "edp-tekton.registry" . }}/bitnami/kubectl:1.25.4"
+          value: "{{ include "edp-tekton.registry" . }}/bitnamilegacy/kubectl:1.25.4"
         - name: EXTRA_COMMANDS
           value:
             echo "Hello World"

--- a/charts/pipelines-library/templates/pipelines/cd/deploy-with-autotests.yaml
+++ b/charts/pipelines-library/templates/pipelines/cd/deploy-with-autotests.yaml
@@ -56,7 +56,7 @@ spec:
         - name: KUBECONFIG_SECRET_NAME
           value: $(params.KUBECONFIG_SECRET_NAME)
         - name: BASE_IMAGE
-          value: "{{ include "edp-tekton.registry" . }}/bitnami/kubectl:1.25.4"
+          value: "{{ include "edp-tekton.registry" . }}/bitnamilegacy/kubectl:1.25.4"
         - name: EXTRA_COMMANDS
           value:
             echo "Hello World"
@@ -89,7 +89,7 @@ spec:
         - name: KUBECONFIG_SECRET_NAME
           value: $(params.KUBECONFIG_SECRET_NAME)
         - name: BASE_IMAGE
-          value: "{{ include "edp-tekton.registry" . }}/bitnami/kubectl:1.25.4"
+          value: "{{ include "edp-tekton.registry" . }}/bitnamilegacy/kubectl:1.25.4"
         - name: EXTRA_COMMANDS
           value:
             echo "Hello World"

--- a/charts/pipelines-library/templates/pipelines/cd/deploy.yaml
+++ b/charts/pipelines-library/templates/pipelines/cd/deploy.yaml
@@ -48,7 +48,7 @@ spec:
         - name: KUBECONFIG_SECRET_NAME
           value: $(params.KUBECONFIG_SECRET_NAME)
         - name: BASE_IMAGE
-          value: "{{ include "edp-tekton.registry" . }}/bitnami/kubectl:1.25.4"
+          value: "{{ include "edp-tekton.registry" . }}/bitnamilegacy/kubectl:1.25.4"
         - name: EXTRA_COMMANDS
           value:
             echo "Hello World"
@@ -81,7 +81,7 @@ spec:
         - name: KUBECONFIG_SECRET_NAME
           value: $(params.KUBECONFIG_SECRET_NAME)
         - name: BASE_IMAGE
-          value: "{{ include "edp-tekton.registry" . }}/bitnami/kubectl:1.25.4"
+          value: "{{ include "edp-tekton.registry" . }}/bitnamilegacy/kubectl:1.25.4"
         - name: EXTRA_COMMANDS
           value:
             echo "Hello World"

--- a/charts/pipelines-library/templates/resources/pruner/cron-job.yaml
+++ b/charts/pipelines-library/templates/resources/pruner/cron-job.yaml
@@ -24,7 +24,7 @@ spec:
                 name: tekton-resource-pruner-scripts
           containers:
             - name: kubectl
-              image: "{{ default "bitnami/kubectl:latest" .Values.tekton.pruner.image }}"
+              image: "{{ default "bitnamilegacy/kubectl:latest" .Values.tekton.pruner.image }}"
               env:
                 - name: NAMESPACE
                   valueFrom:

--- a/charts/pipelines-library/templates/tasks/cd/sync-app.yaml
+++ b/charts/pipelines-library/templates/tasks/cd/sync-app.yaml
@@ -73,7 +73,7 @@ spec:
         sleep 5
 
     - name: argocd-diff
-      image: {{ include "edp-tekton.registry" . }}/bitnami/kubectl:1.25.4
+      image: {{ include "edp-tekton.registry" . }}/bitnamilegacy/kubectl:1.25.4
       env:
         - name: ARGOCD_URL
           valueFrom:

--- a/charts/pipelines-library/templates/tasks/getversion/edptype/GetVersionEDP.yaml
+++ b/charts/pipelines-library/templates/tasks/getversion/edptype/GetVersionEDP.yaml
@@ -12,7 +12,7 @@ spec:
       description: "Codebasebranch name"
     - name: step_get_version_image
       description: "The base image for the task"
-      default: "{{ include "edp-tekton.registry" . }}/bitnami/kubectl:1.25.4"
+      default: "{{ include "edp-tekton.registry" . }}/bitnamilegacy/kubectl:1.25.4"
   results:
     - name: VERSION
       description: "Application version"

--- a/charts/pipelines-library/templates/tasks/init-values.yaml
+++ b/charts/pipelines-library/templates/tasks/init-values.yaml
@@ -18,7 +18,7 @@ spec:
     - name: BASE_IMAGE
       description: The base image for the task.
       type: string
-      default: {{ include "edp-tekton.registry" . }}/bitnami/kubectl:1.25.4
+      default: {{ include "edp-tekton.registry" . }}/bitnamilegacy/kubectl:1.25.4
   results:
     - name: TENANT_NAME
       description: "krci name"

--- a/charts/pipelines-library/templates/tasks/update-cbb.yaml
+++ b/charts/pipelines-library/templates/tasks/update-cbb.yaml
@@ -17,7 +17,7 @@ spec:
     - name: BASE_IMAGE
       description: The base image for the task.
       type: string
-      default: {{ include "edp-tekton.registry" . }}/bitnami/kubectl:1.25.4
+      default: {{ include "edp-tekton.registry" . }}/bitnamilegacy/kubectl:1.25.4
   steps:
     - name: update-cbb-status
       image: $(params.BASE_IMAGE)

--- a/charts/pipelines-library/templates/tasks/update-cbis.yaml
+++ b/charts/pipelines-library/templates/tasks/update-cbis.yaml
@@ -16,7 +16,7 @@ spec:
     - name: BASE_IMAGE
       description: The base image for the task.
       type: string
-      default: {{ include "edp-tekton.registry" . }}/bitnami/kubectl:1.25.4
+      default: {{ include "edp-tekton.registry" . }}/bitnamilegacy/kubectl:1.25.4
   steps:
     - name: update-cbis
       image: $(params.BASE_IMAGE)

--- a/charts/pipelines-library/values.yaml
+++ b/charts/pipelines-library/values.yaml
@@ -199,7 +199,7 @@ tekton:
     # -- How often to clean up resources
     schedule: "0 10 */1 * *"
     # -- Docker image to run the pruner, expected to have kubectl and jq
-    image: bitnami/kubectl:1.25
+    image: bitnamilegacy/kubectl:1.25
     # -- List of ImagePullSecrets to be used by the pruner CronJob
     imagePullSecrets: []
     # -- Pod resources for Tekton pruner job

--- a/hack/images/images.txt
+++ b/hack/images/images.txt
@@ -8,7 +8,7 @@ docker.io/amazon/aws-cli:2.7.35
 docker.io/antora/antora:3.1.4
 docker.io/aquasec/trivy:0.41.0
 docker.io/aquasec/trivy:0.59.1
-docker.io/bitnami/kubectl:1.25.4
+docker.io/bitnamilegacy/kubectl:1.25.4
 docker.io/epamedp/tekton-ansible:0.1.1
 docker.io/epamedp/tekton-autotest:0.1.8
 docker.io/epamedp/tekton-cd-pipeline:0.1.4


### PR DESCRIPTION
# Pull Request: Migration from Deprecated bitnami repo to bitnamilegacy repo

## Description
This PR migrates all usages of deprecated images from the `bitnami` repository to the `bitnamilegacy` repository.  
The change ensures pipeline stability, security compliance, and compatibility with platform requirements.  

Fixes #540

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)  
- [x] New feature (non-breaking change which adds functionality)  
- [ ] Enhancement (non-breaking change which improves an existing feature or documentation)  
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)  

## How Has This Been Tested?
- Updated Tekton tasks were executed in a test environment.  
- Verified that pipelines run successfully with `bitnamilegacy` images.  
- Confirmed no regressions in existing workflows.  

## Checklist:
- [x] I have performed a self-review of my code  
- [x] I have commented on my code, particularly in hard-to-understand areas  
- [x] I have made corresponding changes to the documentation  
- [x] My changes generate no new warnings  
- [ ] I have added tests that prove my fix is effective or that my feature works  
- [x] New and existing unit tests pass locally with my changes  
- [x] Pull Request contains one commit. I squash my commits.  

## Additional context
- Reference: [bitnami/charts#35164](https://github.com/bitnami/charts/issues/35164)  
- This migration is an interim step until a long-term replacement strategy (e.g., upstream or official images) is defined.  
