### PR TITLE
fix: Fix git-sha value for the GitLab when merge strategy doesn't cre…

### DIFF
--- a/charts/pipelines-library/templates/triggers/gitlab/triggerbinding-build.yaml
+++ b/charts/pipelines-library/templates/triggers/gitlab/triggerbinding-build.yaml
@@ -8,7 +8,7 @@ metadata:
 spec:
   params:
     - name: gitrevision
-      value: $(body.object_attributes.merge_commit_sha)
+      value: "$(extensions.pullRequest.headSha)"
     - name: gitbranch
       value: "$(extensions.pullRequest.headRef)"
     - name: targetBranch


### PR DESCRIPTION
## Description
This PR fixes an issue where GitLab webhook payloads return `null` for `merge_commit_sha` when using fast-forward or squash merge strategies, causing build pipelines to fail. The fix changes the triggerbinding to use `extensions.pullRequest.headSha` instead, which correctly maps to the `last_commit.id` field that is always available in GitLab merge request webhooks.

Fixes #569

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Enhancement (non-breaking change which improves an existing feature or documentation)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## How Has This Been Tested?
Tested with GitLab merge request events in an environment configured with fast-forward merge strategy. Verified that the TriggerBinding now correctly extracts the commit SHA from `extensions.pullRequest.headSha`, which is populated by the interceptor from the `last_commit.id` field in the webhook payload.

## Checklist:
- [x] I have performed a self-review of my code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Pull Request contains one commit. I squash my commits.

## Screenshots (if appropriate):
N/A

## Additional context
The GitLab API documentation states that `merge_commit_sha` returns `null` until the MR is merged, and remains `null` for fast-forward merge strategies. The `last_commit.id` field is always available and represents the head commit of the merge request, making it the reliable choice for triggering build pipelines on merge request events.