### PR TITLE
fix: Use merge_commit_sha for GitLab interceptor with fallback to las…

### DIFF
--- a/pkg/event_processor/event.go
+++ b/pkg/event_processor/event.go
@@ -35,12 +35,13 @@ type GitLabUser struct {
 }
 
 type GitLabMergeRequest struct {
-	TargetBranch string       `json:"target_branch"`
-	Title        string       `json:"title"`
-	LastCommit   GitLabCommit `json:"last_commit"`
-	SourceBranch string       `json:"source_branch"`
-	ChangeNumber int          `json:"iid"`
-	Url          string       `json:"url"`
+	TargetBranch   string       `json:"target_branch"`
+	Title          string       `json:"title"`
+	LastCommit     GitLabCommit `json:"last_commit"`
+	SourceBranch   string       `json:"source_branch"`
+	ChangeNumber   int          `json:"iid"`
+	Url            string       `json:"url"`
+	MergeCommitSha string       `json:"merge_commit_sha"`
 }
 
 type GitLabCommit struct {


### PR DESCRIPTION
…t_commit (#569)

Update GitLab event processor to properly handle both merge strategies:
- Use merge_commit_sha when available (regular merge with merge commit)
- Fallback to last_commit.id when merge_commit_sha is null (fast-forward merge)

This ensures the build pipeline triggers with the correct commit SHA regardless of the GitLab merge strategy configured.

Related to #569

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Enhancement (non-breaking change which improves an existing feature or documentation)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.

## Checklist:
- [x] I have performed a self-review of my code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Pull Request contains one commit. I squash my commits.
