### PR TITLE
chore: Update kubectl image to 1.34.2 from deprecated bitnami image

### DIFF
--- a/charts/pipelines-library/README.md
+++ b/charts/pipelines-library/README.md
@@ -132,7 +132,7 @@ Follows [Tekton Interceptor](https://tekton.dev/vault/triggers-main/clusterinter
 | tekton.packageRegistriesSecret.enabled | bool | `false` | Set this as `true` if the secret should be available in Pipelines |
 | tekton.packageRegistriesSecret.name | string | `"package-registries-auth-secret"` | Secret name that will be used in Pipelines. Default: package-registries-auth-secret |
 | tekton.pruner.create | bool | `true` | Specifies whether a cronjob should be created |
-| tekton.pruner.image | string | `"docker.io/bitnamilegacy/kubectl:1.25.4"` | Docker image to run the pruner, expected to have kubectl and jq |
+| tekton.pruner.image | string | `"docker.io/alpine/kubectl:1.34.2"` | Docker image to run the pruner, expected to have kubectl and jq |
 | tekton.pruner.imagePullSecrets | list | `[]` | List of ImagePullSecrets to be used by the pruner CronJob |
 | tekton.pruner.resources | object | `{"limits":{"cpu":"100m","memory":"70Mi"},"requests":{"cpu":"50m","memory":"50Mi"}}` | Pod resources for Tekton pruner job |
 | tekton.pruner.schedule | string | `"0 10 */1 * *"` | How often to clean up resources |

--- a/charts/pipelines-library/templates/pipelines/cd/clean.yaml
+++ b/charts/pipelines-library/templates/pipelines/cd/clean.yaml
@@ -38,7 +38,7 @@ spec:
         - name: KUBECONFIG_SECRET_NAME
           value: $(params.KUBECONFIG_SECRET_NAME)
         - name: BASE_IMAGE
-          value: "{{ include "edp-tekton.registry" . }}/bitnamilegacy/kubectl:1.25.4"
+          value: "{{ include "edp-tekton.registry" . }}/alpine/kubectl:1.34.2"
         - name: EXTRA_COMMANDS
           value:
             echo "Hello World"
@@ -69,7 +69,7 @@ spec:
         - name: KUBECONFIG_SECRET_NAME
           value: $(params.KUBECONFIG_SECRET_NAME)
         - name: BASE_IMAGE
-          value: "{{ include "edp-tekton.registry" . }}/bitnamilegacy/kubectl:1.25.4"
+          value: "{{ include "edp-tekton.registry" . }}/alpine/kubectl:1.34.2"
         - name: EXTRA_COMMANDS
           value:
             echo "Hello World"

--- a/charts/pipelines-library/templates/pipelines/cd/deploy-ansible-awx.yaml
+++ b/charts/pipelines-library/templates/pipelines/cd/deploy-ansible-awx.yaml
@@ -47,7 +47,7 @@ spec:
         - name: ENVIRONMENT
           value: $(params.CDSTAGE)
         - name: BASE_IMAGE
-          value: "{{ include "edp-tekton.registry" . }}/bitnamilegacy/kubectl:1.25.4"
+          value: "{{ include "edp-tekton.registry" . }}/alpine/kubectl:1.34.2"
         - name: EXTRA_COMMANDS
           value:
             echo "Hello World"
@@ -78,7 +78,7 @@ spec:
         - name: ENVIRONMENT
           value: $(params.CDSTAGE)
         - name: BASE_IMAGE
-          value: "{{ include "edp-tekton.registry" . }}/bitnamilegacy/kubectl:1.25.4"
+          value: "{{ include "edp-tekton.registry" . }}/alpine/kubectl:1.34.2"
         - name: EXTRA_COMMANDS
           value:
             echo "Hello World"

--- a/charts/pipelines-library/templates/pipelines/cd/deploy-ansible.yaml
+++ b/charts/pipelines-library/templates/pipelines/cd/deploy-ansible.yaml
@@ -43,7 +43,7 @@ spec:
         - name: ENVIRONMENT
           value: $(params.CDSTAGE)
         - name: BASE_IMAGE
-          value: "{{ include "edp-tekton.registry" . }}/bitnamilegacy/kubectl:1.25.4"
+          value: "{{ include "edp-tekton.registry" . }}/alpine/kubectl:1.34.2"
         - name: EXTRA_COMMANDS
           value:
             echo "Hello World"
@@ -74,7 +74,7 @@ spec:
         - name: ENVIRONMENT
           value: $(params.CDSTAGE)
         - name: BASE_IMAGE
-          value: "{{ include "edp-tekton.registry" . }}/bitnamilegacy/kubectl:1.25.4"
+          value: "{{ include "edp-tekton.registry" . }}/alpine/kubectl:1.34.2"
         - name: EXTRA_COMMANDS
           value:
             echo "Hello World"

--- a/charts/pipelines-library/templates/pipelines/cd/deploy-diff-approve.yaml
+++ b/charts/pipelines-library/templates/pipelines/cd/deploy-diff-approve.yaml
@@ -73,7 +73,7 @@ spec:
         - name: KUBECONFIG_SECRET_NAME
           value: $(params.KUBECONFIG_SECRET_NAME)
         - name: BASE_IMAGE
-          value: "{{ include "edp-tekton.registry" . }}/bitnamilegacy/kubectl:1.25.4"
+          value: "{{ include "edp-tekton.registry" . }}/alpine/kubectl:1.34.2"
         - name: EXTRA_COMMANDS
           value:
             echo "Hello World"
@@ -106,7 +106,7 @@ spec:
         - name: KUBECONFIG_SECRET_NAME
           value: $(params.KUBECONFIG_SECRET_NAME)
         - name: BASE_IMAGE
-          value: "{{ include "edp-tekton.registry" . }}/bitnamilegacy/kubectl:1.25.4"
+          value: "{{ include "edp-tekton.registry" . }}/alpine/kubectl:1.34.2"
         - name: EXTRA_COMMANDS
           value:
             echo "Hello World"

--- a/charts/pipelines-library/templates/pipelines/cd/deploy-with-approve.yaml
+++ b/charts/pipelines-library/templates/pipelines/cd/deploy-with-approve.yaml
@@ -49,7 +49,7 @@ spec:
         - name: KUBECONFIG_SECRET_NAME
           value: $(params.KUBECONFIG_SECRET_NAME)
         - name: BASE_IMAGE
-          value: "{{ include "edp-tekton.registry" . }}/bitnamilegacy/kubectl:1.25.4"
+          value: "{{ include "edp-tekton.registry" . }}/alpine/kubectl:1.34.2"
         - name: EXTRA_COMMANDS
           value:
             echo "Hello World"

--- a/charts/pipelines-library/templates/pipelines/cd/deploy-with-autotests.yaml
+++ b/charts/pipelines-library/templates/pipelines/cd/deploy-with-autotests.yaml
@@ -56,7 +56,7 @@ spec:
         - name: KUBECONFIG_SECRET_NAME
           value: $(params.KUBECONFIG_SECRET_NAME)
         - name: BASE_IMAGE
-          value: "{{ include "edp-tekton.registry" . }}/bitnamilegacy/kubectl:1.25.4"
+          value: "{{ include "edp-tekton.registry" . }}/alpine/kubectl:1.34.2"
         - name: EXTRA_COMMANDS
           value:
             echo "Hello World"
@@ -89,7 +89,7 @@ spec:
         - name: KUBECONFIG_SECRET_NAME
           value: $(params.KUBECONFIG_SECRET_NAME)
         - name: BASE_IMAGE
-          value: "{{ include "edp-tekton.registry" . }}/bitnamilegacy/kubectl:1.25.4"
+          value: "{{ include "edp-tekton.registry" . }}/alpine/kubectl:1.34.2"
         - name: EXTRA_COMMANDS
           value:
             echo "Hello World"

--- a/charts/pipelines-library/templates/pipelines/cd/deploy.yaml
+++ b/charts/pipelines-library/templates/pipelines/cd/deploy.yaml
@@ -48,7 +48,7 @@ spec:
         - name: KUBECONFIG_SECRET_NAME
           value: $(params.KUBECONFIG_SECRET_NAME)
         - name: BASE_IMAGE
-          value: "{{ include "edp-tekton.registry" . }}/bitnamilegacy/kubectl:1.25.4"
+          value: "{{ include "edp-tekton.registry" . }}/alpine/kubectl:1.34.2"
         - name: EXTRA_COMMANDS
           value:
             echo "Hello World"
@@ -81,7 +81,7 @@ spec:
         - name: KUBECONFIG_SECRET_NAME
           value: $(params.KUBECONFIG_SECRET_NAME)
         - name: BASE_IMAGE
-          value: "{{ include "edp-tekton.registry" . }}/bitnamilegacy/kubectl:1.25.4"
+          value: "{{ include "edp-tekton.registry" . }}/alpine/kubectl:1.34.2"
         - name: EXTRA_COMMANDS
           value:
             echo "Hello World"

--- a/charts/pipelines-library/templates/tasks/cd/sync-app.yaml
+++ b/charts/pipelines-library/templates/tasks/cd/sync-app.yaml
@@ -73,7 +73,7 @@ spec:
         sleep 5
 
     - name: argocd-diff
-      image: {{ include "edp-tekton.registry" . }}/bitnamilegacy/kubectl:1.25.4
+      image: {{ include "edp-tekton.registry" . }}/alpine/kubectl:1.34.2
       env:
         - name: ARGOCD_URL
           valueFrom:

--- a/charts/pipelines-library/templates/tasks/getversion/edptype/GetVersionEDP.yaml
+++ b/charts/pipelines-library/templates/tasks/getversion/edptype/GetVersionEDP.yaml
@@ -12,7 +12,7 @@ spec:
       description: "Codebasebranch name"
     - name: step_get_version_image
       description: "The base image for the task"
-      default: "{{ include "edp-tekton.registry" . }}/bitnamilegacy/kubectl:1.25.4"
+      default: "{{ include "edp-tekton.registry" . }}/alpine/kubectl:1.34.2"
   results:
     - name: VERSION
       description: "Application version"

--- a/charts/pipelines-library/templates/tasks/helm-libraries/helm-push-lib.yaml
+++ b/charts/pipelines-library/templates/tasks/helm-libraries/helm-push-lib.yaml
@@ -63,7 +63,7 @@ spec:
           fi
 
     - name: push-helm-chart
-      image: {{ include "edp-tekton.registry" . }}/alpine/k8s:1.25.15
+      image: {{ include "edp-tekton.registry" . }}/alpine/kubectl:1.34.2
       workingDir: $(workspaces.source.path)
       env:
         - name: CHART_DIR

--- a/charts/pipelines-library/templates/tasks/helm-push.yaml
+++ b/charts/pipelines-library/templates/tasks/helm-push.yaml
@@ -55,7 +55,7 @@ spec:
           fi
 
     - name: push-helm-chart
-      image: {{ include "edp-tekton.registry" . }}/alpine/k8s:1.25.15
+      image: {{ include "edp-tekton.registry" . }}/alpine/kubectl:1.34.2
       workingDir: $(workspaces.source.path)
       env:
         - name: IMAGE_TAG

--- a/charts/pipelines-library/templates/tasks/init-values.yaml
+++ b/charts/pipelines-library/templates/tasks/init-values.yaml
@@ -18,7 +18,7 @@ spec:
     - name: BASE_IMAGE
       description: The base image for the task.
       type: string
-      default: {{ include "edp-tekton.registry" . }}/bitnamilegacy/kubectl:1.25.4
+      default: {{ include "edp-tekton.registry" . }}/alpine/kubectl:1.34.2
   results:
     - name: TENANT_NAME
       description: "krci name"

--- a/charts/pipelines-library/templates/tasks/update-cbb.yaml
+++ b/charts/pipelines-library/templates/tasks/update-cbb.yaml
@@ -17,7 +17,7 @@ spec:
     - name: BASE_IMAGE
       description: The base image for the task.
       type: string
-      default: {{ include "edp-tekton.registry" . }}/bitnamilegacy/kubectl:1.25.4
+      default: {{ include "edp-tekton.registry" . }}/alpine/kubectl:1.34.2
   steps:
     - name: update-cbb-status
       image: $(params.BASE_IMAGE)

--- a/charts/pipelines-library/templates/tasks/update-cbis.yaml
+++ b/charts/pipelines-library/templates/tasks/update-cbis.yaml
@@ -16,7 +16,7 @@ spec:
     - name: BASE_IMAGE
       description: The base image for the task.
       type: string
-      default: {{ include "edp-tekton.registry" . }}/bitnamilegacy/kubectl:1.25.4
+      default: {{ include "edp-tekton.registry" . }}/alpine/kubectl:1.34.2
   steps:
     - name: update-cbis
       image: $(params.BASE_IMAGE)

--- a/charts/pipelines-library/values.yaml
+++ b/charts/pipelines-library/values.yaml
@@ -203,7 +203,7 @@ tekton:
     # -- How often to clean up resources
     schedule: "0 10 */1 * *"
     # -- Docker image to run the pruner, expected to have kubectl and jq
-    image: docker.io/bitnamilegacy/kubectl:1.25.4
+    image: docker.io/alpine/kubectl:1.34.2
     # -- List of ImagePullSecrets to be used by the pruner CronJob
     imagePullSecrets: []
     # -- Pod resources for Tekton pruner job

--- a/hack/images/images.txt
+++ b/hack/images/images.txt
@@ -1,7 +1,7 @@
 docker.io/alpine/curl:8.12.0
 docker.io/alpine/git:v2.26.2
 docker.io/alpine/helm:3.11.1
-docker.io/alpine/k8s:1.25.15
+docker.io/alpine/kubectl:1.34.2
 docker.io/alpine/make:4.2.1
 docker.io/alpine:3.18.9
 docker.io/amazon/aws-cli:2.28.3
@@ -12,7 +12,6 @@ docker.io/antora/antora:3.1.4
 docker.io/aquasec/trivy:0.41.0
 docker.io/aquasec/trivy:0.59.1
 docker.io/aquasec/trivy:0.65.0
-docker.io/bitnamilegacy/kubectl:1.25.4
 docker.io/busybox:1.37.0
 docker.io/epamedp/tekton-ansible:0.1.1
 docker.io/epamedp/tekton-autotest:0.1.8
@@ -33,8 +32,8 @@ docker.io/jnorwood/helm-docs:v1.13.1
 docker.io/library/node:22.15.0-alpine3.21
 docker.io/maven:3.9.0-eclipse-temurin-11
 docker.io/maven:3.9.0-eclipse-temurin-17
-docker.io/maven:3.9.9-eclipse-temurin-21
 docker.io/maven:3.9.11-eclipse-temurin-25
+docker.io/maven:3.9.9-eclipse-temurin-21
 docker.io/openpolicyagent/opa:0.45.0-debug
 docker.io/pipelinecomponents/ansible-lint:0.72.0
 docker.io/python:3.10.8-alpine3.16


### PR DESCRIPTION
- Update deprecated bitnamilegacy/kubectl:1.25.4 image references to alpine/kubectl:1.34.2 across pipelines, tasks, and configuration. Also
- update helm-push tasks to use alpine/kubectl instead of alpine/k8s.

