### PR TITLE
fix: Replace bash shebang with sh for POSIX shell compatibility

### DIFF
--- a/charts/pipelines-library/templates/tasks/cd/sync-app.yaml
+++ b/charts/pipelines-library/templates/tasks/cd/sync-app.yaml
@@ -92,7 +92,7 @@ spec:
         - configMapRef:
             name: $(params.DEPLOYMENT_FLOW)-$(params.ENVIRONMENT)
       script: |
-        #!/usr/bin/env bash
+        #!/usr/bin/env sh
         set -e
 
         apps=($(echo $APPLICATIONS_PAYLOAD | jq -r 'keys[]'))

--- a/charts/pipelines-library/templates/tasks/getversion/edptype/GetVersionEDP.yaml
+++ b/charts/pipelines-library/templates/tasks/getversion/edptype/GetVersionEDP.yaml
@@ -37,7 +37,7 @@ spec:
         - name: CODEBASEBRANCH_NAME
           value: "$(params.CODEBASEBRANCH_NAME)"
       script: |
-        #!/usr/bin/env bash
+        #!/usr/bin/env sh
         set -e
 
         # replace '/' with '-'

--- a/charts/pipelines-library/templates/tasks/init-values.yaml
+++ b/charts/pipelines-library/templates/tasks/init-values.yaml
@@ -33,7 +33,7 @@ spec:
         - name: BRANCH
           value: "$(params.BRANCH_NAME)"
       script: |
-        #!/usr/bin/env bash
+        #!/usr/bin/env sh
         set -e
 
         tenantName=$(kubectl get cm krci-config -o jsonpath='{.data.edp_name}')

--- a/charts/pipelines-library/templates/tasks/update-cbb.yaml
+++ b/charts/pipelines-library/templates/tasks/update-cbb.yaml
@@ -27,7 +27,7 @@ spec:
         - name: CURRENT_BUILD_NUMBER
           value: "$(params.CURRENT_BUILD_NUMBER)"
       script: |
-        #!/usr/bin/env bash
+        #!/usr/bin/env sh
         set -ex
 
         kubectl patch codebasebranches.v2.edp.epam.com ${CBB_NAME} \

--- a/charts/pipelines-library/templates/tasks/update-cbis.yaml
+++ b/charts/pipelines-library/templates/tasks/update-cbis.yaml
@@ -26,7 +26,7 @@ spec:
         - name: IMAGE_TAG
           value: "$(params.IMAGE_TAG)"
       script: |
-        #!/usr/bin/env bash
+        #!/usr/bin/env sh
         set -e
 
         cbisName=$(kubectl get cbis.v2.edp.epam.com -l app.edp.epam.com/codebasebranch="${CODEBASEBRANCH_NAME}" -o jsonpath='{.items[0].metadata.name}')


### PR DESCRIPTION
Replace all bash-specific shebangs with POSIX sh to improve script portability across environments where bash may not be available or preferred. This maintains compatibility with container base images that only provide sh.
