### PR TITLE
fix: Refactor task scripts to POSIX sh for Alpine image compatibility

### DIFF
--- a/charts/pipelines-library/templates/tasks/cd/sync-app.yaml
+++ b/charts/pipelines-library/templates/tasks/cd/sync-app.yaml
@@ -95,9 +95,7 @@ spec:
         #!/usr/bin/env sh
         set -e
 
-        apps=($(echo $APPLICATIONS_PAYLOAD | jq -r 'keys[]'))
-
-        for app in "${apps[@]}"; do
+        for app in $(echo "$APPLICATIONS_PAYLOAD" | jq -r 'keys[]'); do
           echo "ArgoCD diff for $app application:"
           echo "${ARGOCD_URL}/applications/${NAMESPACE}/${DEPLOYMENT_FLOW}-${ENVIRONMENT}-$app"
         done

--- a/charts/pipelines-library/templates/tasks/getversion/edptype/GetVersionEDP.yaml
+++ b/charts/pipelines-library/templates/tasks/getversion/edptype/GetVersionEDP.yaml
@@ -41,7 +41,7 @@ spec:
         set -e
 
         # replace '/' with '-'
-        CODEBASEBRANCH_NAME=${CODEBASEBRANCH_NAME//\//-}
+        CODEBASEBRANCH_NAME=$(printf '%s' "$CODEBASEBRANCH_NAME" | tr '/' '-')
         # get current BUILD ID
         BUILD_ID=$(kubectl get codebasebranches.v2.edp.epam.com ${CODEBASEBRANCH_NAME} -o txt --output=jsonpath={.status.build})
         # and increment it

--- a/charts/pipelines-library/templates/tasks/helm-libraries/helm-push-lib.yaml
+++ b/charts/pipelines-library/templates/tasks/helm-libraries/helm-push-lib.yaml
@@ -95,28 +95,26 @@ spec:
               key: platform
               name: krci-config
       script: |
-        #!/bin/bash
+        #!/usr/bin/env sh
         set -ex
 
         helm_push_command="helm push *-*.tgz oci://${CONTAINER_REGISTRY_URL}/${CONTAINER_REGISTRY_SPACE}"
 
-        if [ $CONTAINER_REGISTRY_TYPE != "ecr" ]; then
-          helm_push_command+=" --registry-config /.config/helm/registry/config.json"
+        if [ "$CONTAINER_REGISTRY_TYPE" != "ecr" ]; then
+          helm_push_command="${helm_push_command} --registry-config /.config/helm/registry/config.json"
         fi
 
-        if [ $PLATFORM == "openshift" ]; then
-          helm_push_command+=" --insecure-skip-tls-verify"
+        if [ "$PLATFORM" = "openshift" ]; then
+          helm_push_command="${helm_push_command} --insecure-skip-tls-verify"
         fi
 
-        if [ $CONTAINER_REGISTRY_TYPE == "ecr" ]; then
+        if [ "$CONTAINER_REGISTRY_TYPE" = "ecr" ]; then
           aws ecr get-login-password --region ${AWS_DEFAULT_REGION} | helm registry login --username AWS --password-stdin ${CONTAINER_REGISTRY_URL}
         fi
 
-        chart_directory=(${CHART_DIR}/*)
-        for i in "${chart_directory[@]}"
-        do
-            if ! git diff --quiet HEAD^ HEAD -- $i; then
-                helm package ${i}
+        for i in ${CHART_DIR}/*; do
+            if ! git diff --quiet HEAD^ HEAD -- "$i"; then
+                helm package "${i}"
                 $helm_push_command
                 rm *-*.tgz
             fi

--- a/charts/pipelines-library/templates/tasks/helm-push.yaml
+++ b/charts/pipelines-library/templates/tasks/helm-push.yaml
@@ -89,7 +89,7 @@ spec:
               key: platform
               name: krci-config
       script: |
-        #!/bin/bash
+        #!/usr/bin/env sh
 
         set -ex
 
@@ -98,15 +98,15 @@ spec:
         helm_push_command="helm push *-${IMAGE_TAG}.tgz oci://${CONTAINER_REGISTRY_URL}/${CONTAINER_REGISTRY_SPACE}"
 
 
-        if [ $CONTAINER_REGISTRY_TYPE != "ecr" ]; then
-          helm_push_command+=" --registry-config /.config/helm/registry/config.json"
+        if [ "$CONTAINER_REGISTRY_TYPE" != "ecr" ]; then
+          helm_push_command="${helm_push_command} --registry-config /.config/helm/registry/config.json"
         fi
 
-        if [ $PLATFORM == "openshift" ]; then
-          helm_push_command+=" --insecure-skip-tls-verify"
+        if [ "$PLATFORM" = "openshift" ]; then
+          helm_push_command="${helm_push_command} --insecure-skip-tls-verify"
         fi
 
-        if [ $CONTAINER_REGISTRY_TYPE == "ecr" ]; then
+        if [ "$CONTAINER_REGISTRY_TYPE" = "ecr" ]; then
           aws ecr get-login-password --region ${AWS_DEFAULT_REGION} | helm registry login --username AWS --password-stdin ${CONTAINER_REGISTRY_URL}
         fi
 

--- a/charts/pipelines-library/templates/tasks/init-values.yaml
+++ b/charts/pipelines-library/templates/tasks/init-values.yaml
@@ -39,6 +39,6 @@ spec:
         tenantName=$(kubectl get cm krci-config -o jsonpath='{.data.edp_name}')
         echo "${tenantName}" | tr -d '\n' | tee $(results.TENANT_NAME.path)
 
-        normalizedBranch=$(echo ${BRANCH//[^\(?!.)a-zA-Z0-9]/-} | tr '[:upper:]' '[:lower:]')
+        normalizedBranch=$(printf '%s' "$BRANCH" | sed 's/[^a-zA-Z0-9.]/-/g' | tr '[:upper:]' '[:lower:]')
         printf "%s" "${normalizedBranch}" > "$(results.NORMALIZED_BRANCH.path)"
 {{ end }}

--- a/charts/pipelines-library/templates/tasks/update-cbis.yaml
+++ b/charts/pipelines-library/templates/tasks/update-cbis.yaml
@@ -45,8 +45,13 @@ spec:
         fi
 
         cbisTagsList=$(kubectl get cbis.v2.edp.epam.com ${cbisName} --output=jsonpath={.spec.tags[*].name})
-        if [[ ! ${cbisTagsList} == *"${IMAGE_TAG}"* ]]; then
-            echo "[TEKTON][DEBUG] ImageStream ${cbisName} doesn't contain ${IMAGE_TAG} tag ... it will be added."
-            kubectl patch cbis.v2.edp.epam.com ${cbisName} --type json -p="[{\"op\": \"add\", \"path\": \"/spec/tags/-\", \"value\": ${newcbisTag} }]"
-        fi
+        case "$cbisTagsList" in
+            *"${IMAGE_TAG}"*)
+                # Tag already exists, do nothing
+                ;;
+            *)
+                echo "[TEKTON][DEBUG] ImageStream ${cbisName} doesn't contain ${IMAGE_TAG} tag ... it will be added."
+                kubectl patch cbis.v2.edp.epam.com ${cbisName} --type json -p="[{\"op\": \"add\", \"path\": \"/spec/tags/-\", \"value\": ${newcbisTag} }]"
+                ;;
+        esac
 {{ end }}


### PR DESCRIPTION
Replace bash-specific syntax with POSIX-compliant shell constructs to ensure compatibility with Alpine-based container images that only provide sh. This is critical for tasks using alpine/kubectl:1.34.2 image.

Affected Tasks:
- sync-app: Remove bash array syntax, use direct for loop iteration
- get-version-edp: Replace bash parameter expansion with printf + tr for slash replacement
- init-values: Replace regex parameter expansion with sed for branch normalization
- update-cbis: Replace bash double brackets with POSIX case statement for string matching
- helm-push: Replace bash string append operator with POSIX concatenation
- helm-push-lib: Remove bash arrays and use direct glob expansion with for loop
