### PR TITLE
chore: Add Step Name Parameter Support for Autotest Execution in Depl…

### DIFF
--- a/charts/pipelines-library/templates/pipelines/cd-autotests/autotest.yaml
+++ b/charts/pipelines-library/templates/pipelines/cd-autotests/autotest.yaml
@@ -26,6 +26,8 @@ spec:
       default: "dev"
     - name: base-image
       default: ""
+    - name: step-name
+      default: ""
   tasks:
     - name: fetch-repository
       taskRef:
@@ -55,6 +57,8 @@ spec:
           value: "$(params.cd-pipeline-name)"
         - name: stage-name
           value: "$(params.stage-name)"
+        - name: step-name
+          value: "$(params.step-name)"
       workspaces:
         - name: source
           workspace: shared-workspace

--- a/charts/pipelines-library/templates/tasks/autotest-cd-pipeline/init-autotests.yaml
+++ b/charts/pipelines-library/templates/tasks/autotest-cd-pipeline/init-autotests.yaml
@@ -19,7 +19,7 @@ spec:
     - name: DEPLOYMENT_FLOW
       type: string
     - name: AUTOTEST_PIPELINES
-      default: 'autotes-pipeline'
+      default: 'autotest-pipeline'
     - name: codebase_tags
       default: 'codebase_tags'
     - name: parent-pipeline-name
@@ -63,8 +63,9 @@ spec:
 
         autotestsList = []
         autotestBuildTool = []
-        gitAutotesUrl = []
+        gitAutotestUrl = []
         autotestsBranch = []
+        autotestsStep = []
         pipelines = ""
         applications = []
         tags = []
@@ -93,8 +94,9 @@ spec:
               gitserver = json.loads(subprocess.check_output(["kubectl", "get", "gitserver", autotestGitServer , "-o=jsonpath='{.spec}'"]).decode("utf-8").strip("'"))
               autotestsList.append(element["autotestName"])
               autotestsBranch.append(element["branchName"])
+              autotestsStep.append(f"{cdPipelineName}-{stage}-{element['stepName']}")
               autotest = json.loads(subprocess.check_output(["kubectl", "get", "codebase", element["autotestName"], "-o=jsonpath='{.spec}'"]).decode("utf-8").strip("'"))
-              gitAutotesUrl.append("ssh://" + gitserver['gitUser'] + "@" + gitserver['gitHost'] + ":" + str(gitserver['sshPort']) + autotest['gitUrlPath'])
+              gitAutotestUrl.append("ssh://" + gitserver['gitUser'] + "@" + gitserver['gitHost'] + ":" + str(gitserver['sshPort']) + autotest['gitUrlPath'])
               autotestBuildTool.append(autotest["buildTool"])
               autotestFramework.append(autotest["framework"])
 
@@ -102,15 +104,18 @@ spec:
 
         for count, element in enumerate(autotestsList):
             print("[TEKTON][DEBUG]: Run autotest - autotests-" + autotestBuildTool[count])
-            print("[TEKTON][DEBUG]: Autotest URL - " + gitAutotesUrl[count])
+            print("[TEKTON][DEBUG]: Autotest URL - " + gitAutotestUrl[count])
             print("[TEKTON][DEBUG]: Autotest branch - " + autotestsBranch[count])
+            print("[TEKTON][DEBUG]: Autotest step - " + autotestsStep[count])
             command = "tkn pipeline start autotests-" + autotestBuildTool[count] + " \
             --use-param-defaults \
-            -p git-source-url=" + gitAutotesUrl[count] + " \
+            --serviceaccount tekton \
+            -p git-source-url=" + gitAutotestUrl[count] + " \
             -p git-source-revision=" + autotestsBranch[count] + " \
             -p stage-name=" + stage +" \
             -p cd-pipeline-name=" + cdPipelineName +" \
             -p base-image=" + frameworks[autotestBuildTool[count] + "-" + autotestFramework[count]] + " \
+            -p step-name=" + autotestsStep[count] + " \
             --labels app.edp.epam.com/pipeline=" + cdPipelineName + " \
             --labels app.edp.epam.com/stage=" + stage + " \
             --labels app.edp.epam.com/codebase=" + autotestsList[count] + " \

--- a/charts/pipelines-library/templates/tasks/autotest-cd-pipeline/run-autotests-java.yaml
+++ b/charts/pipelines-library/templates/tasks/autotest-cd-pipeline/run-autotests-java.yaml
@@ -26,24 +26,73 @@ spec:
       type: string
     - name: base-image
       type: string
+    - name: step-name
+      type: string
+    - name: ci-nexus
+      type: string
+      description: name of the secret for the Nexus integration
+      default: ci-nexus
   steps:
     - name: run-autotests
       image: "$(params.base-image)"
+      volumeMounts:
+        {{- if eq $k "maven" }}
+        - name: settings-maven
+          mountPath: /var/configmap
+        {{- else if eq $k "gradle" }}
+        - name: settings-gradle
+          mountPath: /var/configmap
+        {{- end }}
       workingDir: $(workspaces.source.path)
       env:
-        - name: STAGE_NAME
-          value: $(params.stage-name)
-        - name: CD_PIPELINE_NAME
-          value: $(params.cd-pipeline-name)
+        - name: CI_USERNAME
+          valueFrom:
+            secretKeyRef:
+              name: $(params.ci-nexus)
+              key: username
+        - name: CI_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: $(params.ci-nexus)
+              key: password
+        - name: STEP_NAME
+          value: $(params.step-name)
+        - name: BUILD_TOOL
+          value: {{ $k }}
       envFrom:
         - configMapRef:
             name: $(params.cd-pipeline-name)-$(params.stage-name)
       script: |
-        #!/bin/bash
+        #!/usr/bin/env bash
+        set -euo pipefail
 
-        set -exo pipefail
-        $(sed -n 's/.*"'$STAGE_NAME'": "\(.*\)",/\1/p' run.json | awk -F '"' '{print $1}')
+        CMD=$(sed -n "s/.*\"$STEP_NAME\": \"\(.*\)\".*/\1/p" run.json)
+        PARAMS=""
 
+        if [[ -z "$CMD" ]]; then
+          echo "Command for step-name '$STEP_NAME' not found in run.json"
+          exit 1
+        fi
+
+        if [[ $BUILD_TOOL == "maven" ]]; then
+          PARAMS="-s /var/configmap/settings.xml \
+            --batch-mode"
+        elif [[ "$BUILD_TOOL" == "gradle" ]]; then
+          PARAMS="-I \
+            /var/configmap/init.gradle"
+        fi
+
+        exec $CMD $PARAMS
+  volumes:
+    {{- if eq $k "maven" }}
+    - configMap:
+        name: {{ $.Values.tekton.configs.mavenConfigMap }}
+      name: settings-maven
+    {{- else if eq $k "gradle" }}
+    - configMap:
+        name: {{ $.Values.tekton.configs.gradleConfigMap }}
+      name: settings-gradle
+    {{- end }}
 ---
 {{ end }}
 {{ end }}


### PR DESCRIPTION
chore: Add Step Name Parameter Support for Autotest Execution in Deploy Pipeline

## Description
Add step name as a parameter to the Tekton autotest pipeline execution, enabling the same autotest to be executed multiple times within a single deploy pipeline with different step names.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Enhancement (non-breaking change which improves an existing feature or documentation)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)


## Checklist:
- [x] I have performed a self-review of my code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Pull Request contains one commit. I squash my commits.
