### PR TITLE
refactor: consolidate Bitbucket event processing to eliminate duplica…

### DIFF
--- a/pkg/event_processor/bitbucket/bitbucket_test.go
+++ b/pkg/event_processor/bitbucket/bitbucket_test.go
@@ -96,57 +96,55 @@ func TestBitbucketEventProcessor_processCommentEvent(t *testing.T) {
 		{
 			name: "comment event process successfully",
 			args: args{
-				body: event_processor.BitbucketCommentEvent{
-					BitbucketEvent: event_processor.BitbucketEvent{
-						Repository: event_processor.BitbucketRepository{
-							FullName: "o/r",
-						},
-						PullRequest: event_processor.BitbucketPullRequest{
-							ID:    1,
-							Title: "fix",
-							Source: event_processor.BitbucketPullRequestSrc{
-								Branch: event_processor.BitbucketBranch{
-									Name: "feature1",
-								},
-								Commit: event_processor.BitbucketCommit{
-									Hash: "123",
-								},
+				body: event_processor.BitbucketEvent{
+					Repository: event_processor.BitbucketRepository{
+						FullName: "o/r",
+					},
+					PullRequest: event_processor.BitbucketPullRequest{
+						ID:    1,
+						Title: "fix",
+						Source: event_processor.BitbucketPullRequestSrc{
+							Branch: event_processor.BitbucketBranch{
+								Name: "feature1",
 							},
-							Destination: event_processor.BitbucketPullRequestDest{
-								Branch: event_processor.BitbucketBranch{
-									Name: "master",
-								},
-								Commit: event_processor.BitbucketCommit{
-									Hash: "456",
-								},
-							},
-							LastCommit: event_processor.BitbucketCommit{
+							Commit: event_processor.BitbucketCommit{
 								Hash: "123",
 							},
-							Author: event_processor.BitbucketAuthor{
-								DisplayName: "bbuser",
-								Links: struct {
-									Avatar struct {
-										Href string `json:"href"`
-									} `json:"avatar"`
+						},
+						Destination: event_processor.BitbucketPullRequestDest{
+							Branch: event_processor.BitbucketBranch{
+								Name: "master",
+							},
+							Commit: event_processor.BitbucketCommit{
+								Hash: "456",
+							},
+						},
+						LastCommit: event_processor.BitbucketCommit{
+							Hash: "123",
+						},
+						Author: event_processor.BitbucketAuthor{
+							DisplayName: "bbuser",
+							Links: struct {
+								Avatar struct {
+									Href string `json:"href"`
+								} `json:"avatar"`
+							}{
+								Avatar: struct {
+									Href string `json:"href"`
 								}{
-									Avatar: struct {
-										Href string `json:"href"`
-									}{
-										Href: "https://bitbucket.org/avatar/bbuser",
-									},
+									Href: "https://bitbucket.org/avatar/bbuser",
 								},
 							},
-							Links: struct {
-								Html struct {
-									Href string `json:"href"`
-								} `json:"html"`
+						},
+						Links: struct {
+							Html struct {
+								Href string `json:"href"`
+							} `json:"html"`
+						}{
+							Html: struct {
+								Href string `json:"href"`
 							}{
-								Html: struct {
-									Href string `json:"href"`
-								}{
-									Href: "https://bitbucket.org/o/r/pull-requests/1",
-								},
+								Href: "https://bitbucket.org/o/r/pull-requests/1",
 							},
 						},
 					},
@@ -191,33 +189,31 @@ func TestBitbucketEventProcessor_processCommentEvent(t *testing.T) {
 		{
 			name: "pr doesn't contain commits",
 			args: args{
-				body: event_processor.BitbucketCommentEvent{
-					BitbucketEvent: event_processor.BitbucketEvent{
-						Repository: event_processor.BitbucketRepository{
-							FullName: "o/r",
-						},
-						PullRequest: event_processor.BitbucketPullRequest{
-							ID:    2,
-							Title: "fix",
-							Source: event_processor.BitbucketPullRequestSrc{
-								Branch: event_processor.BitbucketBranch{
-									Name: "feature1",
-								},
-								Commit: event_processor.BitbucketCommit{
-									Hash: "123",
-								},
+				body: event_processor.BitbucketEvent{
+					Repository: event_processor.BitbucketRepository{
+						FullName: "o/r",
+					},
+					PullRequest: event_processor.BitbucketPullRequest{
+						ID:    2,
+						Title: "fix",
+						Source: event_processor.BitbucketPullRequestSrc{
+							Branch: event_processor.BitbucketBranch{
+								Name: "feature1",
 							},
-							Destination: event_processor.BitbucketPullRequestDest{
-								Branch: event_processor.BitbucketBranch{
-									Name: "master",
-								},
-								Commit: event_processor.BitbucketCommit{
-									Hash: "456",
-								},
-							},
-							LastCommit: event_processor.BitbucketCommit{
+							Commit: event_processor.BitbucketCommit{
 								Hash: "123",
 							},
+						},
+						Destination: event_processor.BitbucketPullRequestDest{
+							Branch: event_processor.BitbucketBranch{
+								Name: "master",
+							},
+							Commit: event_processor.BitbucketCommit{
+								Hash: "456",
+							},
+						},
+						LastCommit: event_processor.BitbucketCommit{
+							Hash: "123",
 						},
 					},
 					Comment: event_processor.BitbucketComment{
@@ -237,7 +233,7 @@ func TestBitbucketEventProcessor_processCommentEvent(t *testing.T) {
 		{
 			name: "repository path empty",
 			args: args{
-				body: event_processor.BitbucketCommentEvent{},
+				body: event_processor.BitbucketEvent{},
 			},
 			wantErr: func(t require.TestingT, err error, i ...interface{}) {
 				require.Error(t, err)
@@ -247,33 +243,31 @@ func TestBitbucketEventProcessor_processCommentEvent(t *testing.T) {
 		{
 			name: "failed to get codebase",
 			args: args{
-				body: event_processor.BitbucketCommentEvent{
-					BitbucketEvent: event_processor.BitbucketEvent{
-						Repository: event_processor.BitbucketRepository{
-							FullName: "o/r",
-						},
-						PullRequest: event_processor.BitbucketPullRequest{
-							ID:    1,
-							Title: "fix",
-							Source: event_processor.BitbucketPullRequestSrc{
-								Branch: event_processor.BitbucketBranch{
-									Name: "feature1",
-								},
-								Commit: event_processor.BitbucketCommit{
-									Hash: "123",
-								},
+				body: event_processor.BitbucketEvent{
+					Repository: event_processor.BitbucketRepository{
+						FullName: "o/r",
+					},
+					PullRequest: event_processor.BitbucketPullRequest{
+						ID:    1,
+						Title: "fix",
+						Source: event_processor.BitbucketPullRequestSrc{
+							Branch: event_processor.BitbucketBranch{
+								Name: "feature1",
 							},
-							Destination: event_processor.BitbucketPullRequestDest{
-								Branch: event_processor.BitbucketBranch{
-									Name: "master",
-								},
-								Commit: event_processor.BitbucketCommit{
-									Hash: "456",
-								},
-							},
-							LastCommit: event_processor.BitbucketCommit{
+							Commit: event_processor.BitbucketCommit{
 								Hash: "123",
 							},
+						},
+						Destination: event_processor.BitbucketPullRequestDest{
+							Branch: event_processor.BitbucketBranch{
+								Name: "master",
+							},
+							Commit: event_processor.BitbucketCommit{
+								Hash: "456",
+							},
+						},
+						LastCommit: event_processor.BitbucketCommit{
+							Hash: "123",
 						},
 					},
 					Comment: event_processor.BitbucketComment{
@@ -305,7 +299,7 @@ func TestBitbucketEventProcessor_processCommentEvent(t *testing.T) {
 					RestyClient: resty.New().SetBaseURL(server.URL),
 				},
 			)
-			got, err := p.processCommentEvent(context.Background(), body, "default")
+			got, err := p.Process(context.Background(), body, "default", event_processor.BitbucketEventTypeCommentAdded)
 
 			tt.wantErr(t, err)
 			assert.Equal(t, tt.want, got)
@@ -484,7 +478,7 @@ func TestEventProcessor_processMergeEvent(t *testing.T) {
 		{
 			name: "repository path empty",
 			args: args{
-				body: event_processor.BitbucketCommentEvent{},
+				body: event_processor.BitbucketEvent{},
 			},
 			wantErr: func(t require.TestingT, err error, i ...interface{}) {
 				require.Error(t, err)
@@ -634,7 +628,7 @@ func TestEventProcessor_processMergeEvent(t *testing.T) {
 					RestyClient: resty.New().SetBaseURL(server.URL),
 				},
 			)
-			got, err := p.processMergeEvent(context.Background(), body, "default")
+			got, err := p.Process(context.Background(), body, "default", "")
 
 			tt.wantErr(t, err)
 			assert.Equal(t, tt.want, got)

--- a/pkg/event_processor/event.go
+++ b/pkg/event_processor/event.go
@@ -64,11 +64,7 @@ type GitLabComment struct {
 type BitbucketEvent struct {
 	Repository  BitbucketRepository  `json:"repository"`
 	PullRequest BitbucketPullRequest `json:"pullrequest"`
-}
-
-type BitbucketCommentEvent struct {
-	BitbucketEvent
-	Comment BitbucketComment `json:"comment"`
+	Comment     BitbucketComment     `json:"comment"`
 }
 
 type BitbucketRepository struct {


### PR DESCRIPTION
…tion

- Remove processMergeEvent and processCommentEvent private methods
- Consolidate all event processing logic into the public Process method
- Use a single unmarshal into BitbucketEvent for all event types
- Add switch statement to differentiate event type at the end (2-field override)
- Move Comment field from BitbucketCommentEvent into BitbucketEvent
- Remove BitbucketCommentEvent type (dead code via embedding)
- Update tests to use public Process API instead of private methods

Eliminates 33 lines of duplicated logic within the same file (~27% code reduction). Follows existing patterns used in Gerrit processor for consistency. All tests pass with identical coverage (84.2%).
