### PR TITLE
ci: exclude Python from SBOM generation

### DIFF
--- a/.cdxgen.yml
+++ b/.cdxgen.yml
@@ -1,0 +1,2 @@
+exclude-type:
+  - python


### PR DESCRIPTION
Exclude Python from cdxgen SBOM analysis to prevent test-only dependencies from being included. Python is only used for Helm chart testing (pytest, PyYAML, etc.) and not part of the production distribution.

