### PR TITLE
refactor: parameterize container images in security tasks for central…

### DIFF
--- a/charts/pipelines-library/templates/tasks/cdxgen.yaml
+++ b/charts/pipelines-library/templates/tasks/cdxgen.yaml
@@ -23,6 +23,10 @@ spec:
       type: string
       description: Name of the secret holding the ci-dependency-track api token
       default: ci-dependency-track
+    - name: BASE_IMAGE
+      type: string
+      description: CycloneDX cdxgen image
+      default: "{{ include "edp-tekton.registry" . }}/cyclonedx/cdxgen:v11.1.10@sha256:f600e2a51c8bf1f50cca8c8dd89e838daca62e2b94b7c6caf14595451f247e7c"
   steps:
     - env:
         - name: API_TOKEN
@@ -37,8 +41,7 @@ spec:
               key: url
         - name: PROJECT_NAME
           value: $(params.PROJECT_NAME)
-      image: >-
-        ghcr.io/cyclonedx/cdxgen:v9.6.0@sha256:ea01324872d2c21b024264a2224d761ab63851b9cc4722903b5e74be56ca6fa6
+      image: $(params.BASE_IMAGE)
       name: cdxgen
       computeResources: {}
       script: >

--- a/charts/pipelines-library/templates/tasks/image-scan-remote.yaml
+++ b/charts/pipelines-library/templates/tasks/image-scan-remote.yaml
@@ -28,6 +28,10 @@ spec:
       description: Name of the component to which the images belong.
         Pipeline will use this name to create/update the appropriate
         Engagement with scan reports in DefectDojo.
+    - name: BASE_IMAGE_AWS_CLI
+      type: string
+      description: AWS CLI image
+      default: "{{ include "edp-tekton.registry" . }}/amazon/aws-cli:2.28.3"
     - name: BASE_IMAGE_TRIVY
       type: string
       default: "{{ include "edp-tekton.registry" . }}/aquasec/trivy:0.69.0"
@@ -54,7 +58,7 @@ spec:
       description: DefectDojo URL with the generated vulnerability scan reports
   steps:
     - name: get-ecr-pass
-      image: {{ include "edp-tekton.registry" . }}/amazon/aws-cli:2.28.3
+      image: $(params.BASE_IMAGE_AWS_CLI)
       env:
         - name: ECR_LOGIN
           value: "$(params.ECR_LOGIN)"

--- a/charts/pipelines-library/templates/tasks/security.yaml
+++ b/charts/pipelines-library/templates/tasks/security.yaml
@@ -25,6 +25,10 @@ spec:
       type: string
       description: Gitleaks image
       default: {{ include "edp-tekton.registry" . }}/zricethezav/gitleaks:v8.30.0
+    - name: BASE_IMAGE_CDXGEN
+      type: string
+      description: CycloneDX cdxgen image
+      default: "{{ include "edp-tekton.registry" . }}/cyclonedx/cdxgen:v11.1.10@sha256:f600e2a51c8bf1f50cca8c8dd89e838daca62e2b94b7c6caf14595451f247e7c"
     - name: BASE_IMAGE
       type: string
       default: "{{ include "edp-tekton.registry" . }}/epamedp/tekton-autotest:0.1.8"
@@ -120,8 +124,7 @@ spec:
           value: $(params.PROJECT_NAME)
         - name: PROJECT_BRANCH
           value: $(params.PROJECT_BRANCH)
-      image: >-
-        ghcr.io/cyclonedx/cdxgen:v11.1.10@sha256:f600e2a51c8bf1f50cca8c8dd89e838daca62e2b94b7c6caf14595451f247e7c
+      image: $(params.BASE_IMAGE_CDXGEN)
       name: cdxgen
       computeResources: {}
       script: >

--- a/hack/images/images.txt
+++ b/hack/images/images.txt
@@ -9,6 +9,7 @@ docker.io/anchore/grype:v0.107.0-debug
 docker.io/antora/antora:3.1.4
 docker.io/aquasec/trivy:0.69.0
 docker.io/busybox:1.37.0
+docker.io/cyclonedx/cdxgen:v11.1.10@sha256:f600e2a51c8bf1f50cca8c8dd89e838daca62e2b94b7c6caf14595451f247e7c
 docker.io/epamedp/kubectl:0.1.1
 docker.io/epamedp/tekton-ansible:0.1.1
 docker.io/epamedp/tekton-autotest:0.1.8

--- a/hack/images/update_image_list.py
+++ b/hack/images/update_image_list.py
@@ -20,7 +20,7 @@ def run_helm_template():
 def extract_docker_images(manifests):
     """Extract all unique images from 'docker.io' registry in the manifests."""
     # Regex pattern to match images from docker.io
-    docker_image_pattern = re.compile(r"docker\.io/[a-zA-Z0-9._/-]+:[a-zA-Z0-9._-]+")
+    docker_image_pattern = re.compile(r"docker\.io/[a-zA-Z0-9._/-]+:[a-zA-Z0-9._-]+(?:@sha256:[a-fA-F0-9]+)?")
     images = set(docker_image_pattern.findall(manifests))  # Use a set to remove duplicates
     return sorted(images)  # Sort the images alphabetically
 


### PR DESCRIPTION
…ized management

- Add BASE_IMAGE parameters to cdxgen, security, and image-scan-remote tasks
- Replace hardcoded image references with parameter substitution
- Update cdxgen image version from v9.6.0 to v11.1.10 for consistency across tasks
- Enable image registry configuration via helm values through edp-tekton.registry helper
- Extend image list parser to capture sha256 digest suffixes for reproducible builds
