### PR TITLE
fix: correct cdxgen image registry from docker.io to ghcr.io

### DIFF
--- a/charts/pipelines-library/templates/tasks/cdxgen.yaml
+++ b/charts/pipelines-library/templates/tasks/cdxgen.yaml
@@ -26,7 +26,7 @@ spec:
     - name: BASE_IMAGE
       type: string
       description: CycloneDX cdxgen image
-      default: "{{ include "edp-tekton.registry" . }}/cyclonedx/cdxgen:v11.1.10@sha256:f600e2a51c8bf1f50cca8c8dd89e838daca62e2b94b7c6caf14595451f247e7c"
+      default: "ghcr.io/cyclonedx/cdxgen:v11.1.10@sha256:f600e2a51c8bf1f50cca8c8dd89e838daca62e2b94b7c6caf14595451f247e7c"
   steps:
     - env:
         - name: API_TOKEN

--- a/charts/pipelines-library/templates/tasks/security.yaml
+++ b/charts/pipelines-library/templates/tasks/security.yaml
@@ -28,7 +28,7 @@ spec:
     - name: BASE_IMAGE_CDXGEN
       type: string
       description: CycloneDX cdxgen image
-      default: "{{ include "edp-tekton.registry" . }}/cyclonedx/cdxgen:v11.1.10@sha256:f600e2a51c8bf1f50cca8c8dd89e838daca62e2b94b7c6caf14595451f247e7c"
+      default: "ghcr.io/cyclonedx/cdxgen:v11.1.10@sha256:f600e2a51c8bf1f50cca8c8dd89e838daca62e2b94b7c6caf14595451f247e7c"
     - name: BASE_IMAGE
       type: string
       default: "{{ include "edp-tekton.registry" . }}/epamedp/tekton-autotest:0.1.8"

--- a/hack/images/images.txt
+++ b/hack/images/images.txt
@@ -9,7 +9,6 @@ docker.io/anchore/grype:v0.107.0-debug
 docker.io/antora/antora:3.1.4
 docker.io/aquasec/trivy:0.69.0
 docker.io/busybox:1.37.0
-docker.io/cyclonedx/cdxgen:v11.1.10@sha256:f600e2a51c8bf1f50cca8c8dd89e838daca62e2b94b7c6caf14595451f247e7c
 docker.io/epamedp/kubectl:0.1.1
 docker.io/epamedp/tekton-ansible:0.1.1
 docker.io/epamedp/tekton-autotest:0.1.8


### PR DESCRIPTION
  The previous commit incorrectly parameterized cdxgen image references
  using the edp-tekton.registry helper, which defaults to docker.io.
  However, CycloneDX cdxgen is not available on Docker Hub but is hosted
  on ghcr.io. Update both task parameter defaults to use the correct
  registry with the proper digest, and remove the incorrect docker.io
  entry from the images list.
