### PR TITLE
fix: Add support java21/25 for Deployment autotests

### DIFF
--- a/charts/pipelines-library/templates/tasks/autotest-cd-pipeline/init-autotests.yaml
+++ b/charts/pipelines-library/templates/tasks/autotest-cd-pipeline/init-autotests.yaml
@@ -73,12 +73,12 @@ spec:
         gitSecret = {}
 
         frameworks = {
-          "gradle-java8": "gradle:7.6.5-jdk8",
-          "gradle-java11": "gradle:7.6.5-jdk11",
           "gradle-java17": "gradle:7.6.5-jdk17",
-          "maven-java8": "maven:3.9.0-eclipse-temurin-8",
-          "maven-java11": "maven:3.9.0-eclipse-temurin-11",
+          "gradle-java21": "gradle:8.11-jdk21",
+          "gradle-java25": "gradle:9.2.1-jdk25",
           "maven-java17": "maven:3.9.0-eclipse-temurin-17"
+          "maven-java21": "maven:3.9.9-eclipse-temurin-21"
+          "maven-java25": "maven:3.9.11-eclipse-temurin-25"
         }
         cdPipelineName = os.getenv('DEPLOYMENT_FLOW')
         stage = os.getenv('ENVIRONMENT')


### PR DESCRIPTION
## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Enhancement (non-breaking change which improves an existing feature or documentation)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist:
- [x] I have performed a self-review of my code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Pull Request contains one commit. I squash my commits.
