### PR TITLE
EPMDEDP-16665: fix(gitlab): fix tags on squash + ff enabled

### DIFF
--- a/charts/common-library/templates/_common_gitlab.yaml
+++ b/charts/common-library/templates/_common_gitlab.yaml
@@ -4,6 +4,8 @@
   taskRef:
     kind: Task
     name: gitlab-set-status
+  runAfter:
+    - fetch-repository
   when:
     - input: $(params.COMMIT_MESSAGE)
       operator: notin
@@ -20,7 +22,7 @@
     - name: "GITLAB_TOKEN_SECRET_KEY"
       value: token
     - name: "SHA"
-      value: "$(params.git-source-revision)"
+      value: "$(tasks.fetch-repository.results.commit)"
     - name: "TARGET_URL"
       value: $(params.pipelineUrl)
     - name: "CONTEXT"
@@ -36,7 +38,7 @@
     - name: url
       value: $(params.git-source-url)
     - name: revision
-      value: $(params.git-source-revision)
+      value: $(params.targetBranch)
     - name: subdirectory
       value: source
   workspaces:
@@ -55,7 +57,7 @@
     - name: CODEBASE_NAME
       value: $(params.CODEBASE_NAME)
     - name: BRANCH_NAME
-      value: $(params.git-source-revision)
+      value: $(params.targetBranch)
 {{- end -}}
 
 # The init section for gitlab code-review pipeline
@@ -204,7 +206,7 @@ finally:
     - name: "GITLAB_TOKEN_SECRET_KEY"
       value: token
     - name: "SHA"
-      value: "$(params.git-source-revision)"
+      value: "$(tasks.fetch-repository.results.commit)"
     - name: "TARGET_URL"
       value: $(params.pipelineUrl)
     - name: "CONTEXT"
@@ -235,7 +237,7 @@ finally:
     - name: "GITLAB_TOKEN_SECRET_KEY"
       value: token
     - name: "SHA"
-      value: "$(params.git-source-revision)"
+      value: "$(tasks.fetch-repository.results.commit)"
     - name: "TARGET_URL"
       value: $(params.pipelineUrl)
     - name: "CONTEXT"

--- a/charts/pipelines-library/templates/pipelines/autotests/gradle/gitlab-build-edp.yaml
+++ b/charts/pipelines-library/templates/pipelines/autotests/gradle/gitlab-build-edp.yaml
@@ -38,6 +38,10 @@ spec:
       description: 'git revision to checkout (branch, tag, sha, ref…)'
       default: "edp"
       type: string
+    - name: targetBranch
+      description: 'Target branch of Merge Request'
+      default: "main"
+      type: string
     - name: CODEBASE_NAME
       default: '{{ $framework }}-gradle'
       description: "Project name"

--- a/charts/pipelines-library/templates/pipelines/autotests/maven/gitlab-build-edp.yaml
+++ b/charts/pipelines-library/templates/pipelines/autotests/maven/gitlab-build-edp.yaml
@@ -40,6 +40,10 @@ spec:
       description: 'git revision to checkout (branch, tag, sha, ref…)'
       default: "edp"
       type: string
+    - name: targetBranch
+      description: 'Target branch of Merge Request'
+      default: "main"
+      type: string
     - name: CODEBASE_NAME
       default: '{{ $framework }}-maven'
       description: "Project name"

--- a/charts/pipelines-library/templates/pipelines/c/cmake/gitlab-build-edp.yaml
+++ b/charts/pipelines-library/templates/pipelines/c/cmake/gitlab-build-edp.yaml
@@ -28,6 +28,10 @@ spec:
       description: 'git revision to checkout (branch, tag, sha, ref…)'
       default: "master"
       type: string
+    - name: targetBranch
+      description: 'Target branch of Merge Request'
+      default: "main"
+      type: string
     - name: CODEBASE_NAME
       default: "make-c"
       description: "Project name"

--- a/charts/pipelines-library/templates/pipelines/c/make/gitlab-build-edp.yaml
+++ b/charts/pipelines-library/templates/pipelines/c/make/gitlab-build-edp.yaml
@@ -28,6 +28,10 @@ spec:
       description: 'git revision to checkout (branch, tag, sha, ref…)'
       default: "master"
       type: string
+    - name: targetBranch
+      description: 'Target branch of Merge Request'
+      default: "main"
+      type: string
     - name: CODEBASE_NAME
       default: "make-c"
       description: "Project name"

--- a/charts/pipelines-library/templates/pipelines/csharp/gitlab-build-default.yaml
+++ b/charts/pipelines-library/templates/pipelines/csharp/gitlab-build-default.yaml
@@ -30,6 +30,10 @@ spec:
       description: 'git revision to checkout (branch, tag, sha, ref…)'
       default: "edp"
       type: string
+    - name: targetBranch
+      description: 'Target branch of Merge Request'
+      default: "main"
+      type: string
     - name: CODEBASE_NAME
       default: 'csharp-dotnet-{{ $framework }}'
       description: "Project name"

--- a/charts/pipelines-library/templates/pipelines/csharp/gitlab-build-edp.yaml
+++ b/charts/pipelines-library/templates/pipelines/csharp/gitlab-build-edp.yaml
@@ -30,6 +30,10 @@ spec:
       description: 'git revision to checkout (branch, tag, sha, ref…)'
       default: "edp"
       type: string
+    - name: targetBranch
+      description: 'Target branch of Merge Request'
+      default: "main"
+      type: string
     - name: CODEBASE_NAME
       default: 'csharp-dotnet-{{ $framework }}'
       description: "Project name"

--- a/charts/pipelines-library/templates/pipelines/csharp/gitlab-build-lib-default.yaml
+++ b/charts/pipelines-library/templates/pipelines/csharp/gitlab-build-lib-default.yaml
@@ -30,6 +30,10 @@ spec:
       description: 'git revision to checkout (branch, tag, sha, ref…)'
       default: "edp"
       type: string
+    - name: targetBranch
+      description: 'Target branch of Merge Request'
+      default: "main"
+      type: string
     - name: CODEBASE_NAME
       default: 'csharp-dotnet-{{ $framework }}'
       description: "Project name"

--- a/charts/pipelines-library/templates/pipelines/csharp/gitlab-build-lib-edp.yaml
+++ b/charts/pipelines-library/templates/pipelines/csharp/gitlab-build-lib-edp.yaml
@@ -30,6 +30,10 @@ spec:
       description: 'git revision to checkout (branch, tag, sha, ref…)'
       default: "edp"
       type: string
+    - name: targetBranch
+      description: 'Target branch of Merge Request'
+      default: "main"
+      type: string
     - name: CODEBASE_NAME
       default: 'csharp-dotnet-{{ $framework }}'
       description: "Project name"

--- a/charts/pipelines-library/templates/pipelines/docker/kaniko/gitlab-build-edp.yaml
+++ b/charts/pipelines-library/templates/pipelines/docker/kaniko/gitlab-build-edp.yaml
@@ -28,6 +28,10 @@ spec:
       description: 'git revision to checkout (branch, tag, sha, ref…)'
       default: "edp"
       type: string
+    - name: targetBranch
+      description: 'Target branch of Merge Request'
+      default: "main"
+      type: string
     - name: CODEBASE_NAME
       default: 'docker-kaniko'
       description: "Project name"

--- a/charts/pipelines-library/templates/pipelines/gitops/gitlab-build.yaml
+++ b/charts/pipelines-library/templates/pipelines/gitops/gitlab-build.yaml
@@ -25,6 +25,10 @@ spec:
       description: 'git revision to checkout (branch, tag, sha, ref…)'
       default: "main"
       type: string
+    - name: targetBranch
+      description: 'Target branch of Merge Request'
+      default: "main"
+      type: string
     - name: CODEBASE_NAME
       default: krci-gitops
       description: "Project name"

--- a/charts/pipelines-library/templates/pipelines/go/gitlab-build-edp.yaml
+++ b/charts/pipelines-library/templates/pipelines/go/gitlab-build-edp.yaml
@@ -32,6 +32,10 @@ spec:
       description: 'git revision to checkout (branch, tag, sha, ref…)'
       default: "master"
       type: string
+    - name: targetBranch
+      description: 'Target branch of Merge Request'
+      default: "main"
+      type: string
     - name: CODEBASE_NAME
       default: "{{ $framework }}-go"
       description: "Project name"

--- a/charts/pipelines-library/templates/pipelines/groovy/gitlab-build-lib-edp.yaml
+++ b/charts/pipelines-library/templates/pipelines/groovy/gitlab-build-lib-edp.yaml
@@ -28,6 +28,10 @@ spec:
       description: 'git revision to checkout (branch, tag, sha, ref…)'
       default: "master"
       type: string
+    - name: targetBranch
+      description: 'Target branch of Merge Request'
+      default: "main"
+      type: string
     - name: CODEBASE_NAME
       default: 'groovy-pipeline'
       description: "Project name"

--- a/charts/pipelines-library/templates/pipelines/helm-pipelines/gitlab-build-lib-edp.yaml
+++ b/charts/pipelines-library/templates/pipelines/helm-pipelines/gitlab-build-lib-edp.yaml
@@ -28,6 +28,10 @@ spec:
       description: 'git revision to checkout (branch, tag, sha, ref…)'
       default: "edp"
       type: string
+    - name: targetBranch
+      description: 'Target branch of Merge Request'
+      default: "main"
+      type: string
     - name: CODEBASE_NAME
       description: "Project name"
       type: string

--- a/charts/pipelines-library/templates/pipelines/helm/gitlab-build-default.yaml
+++ b/charts/pipelines-library/templates/pipelines/helm/gitlab-build-default.yaml
@@ -28,6 +28,10 @@ spec:
       description: 'git revision to checkout (branch, tag, sha, ref…)'
       default: "edp"
       type: string
+    - name: targetBranch
+      description: 'Target branch of Merge Request'
+      default: "main"
+      type: string
     - name: CODEBASE_NAME
       description: "Project name"
       type: string

--- a/charts/pipelines-library/templates/pipelines/helm/gitlab-build-edp.yaml
+++ b/charts/pipelines-library/templates/pipelines/helm/gitlab-build-edp.yaml
@@ -28,6 +28,10 @@ spec:
       description: 'git revision to checkout (branch, tag, sha, ref…)'
       default: "edp"
       type: string
+    - name: targetBranch
+      description: 'Target branch of Merge Request'
+      default: "main"
+      type: string
     - name: CODEBASE_NAME
       description: "Project name"
       type: string

--- a/charts/pipelines-library/templates/pipelines/helm/gitlab-build-lib-edp.yaml
+++ b/charts/pipelines-library/templates/pipelines/helm/gitlab-build-lib-edp.yaml
@@ -28,6 +28,10 @@ spec:
       description: 'git revision to checkout (branch, tag, sha, ref…)'
       default: "edp"
       type: string
+    - name: targetBranch
+      description: 'Target branch of Merge Request'
+      default: "main"
+      type: string
     - name: CODEBASE_NAME
       description: "Project name"
       type: string

--- a/charts/pipelines-library/templates/pipelines/infrastructure/gitlab-build-edp.yaml
+++ b/charts/pipelines-library/templates/pipelines/infrastructure/gitlab-build-edp.yaml
@@ -28,6 +28,10 @@ spec:
       description: 'git revision to checkout (branch, tag, sha, ref…)'
       default: "master"
       type: string
+    - name: targetBranch
+      description: 'Target branch of Merge Request'
+      default: "main"
+      type: string
     - name: CODEBASE_NAME
       default: 'terraform-terraform'
       description: "Project name"

--- a/charts/pipelines-library/templates/pipelines/java/gradle/gitlab-build-edp.yaml
+++ b/charts/pipelines-library/templates/pipelines/java/gradle/gitlab-build-edp.yaml
@@ -41,6 +41,10 @@ spec:
       description: 'git revision to checkout (branch, tag, sha, ref…)'
       default: "edp"
       type: string
+    - name: targetBranch
+      description: 'Target branch of Merge Request'
+      default: "main"
+      type: string
     - name: CODEBASE_NAME
       default: '{{ $framework }}-maven'
       description: "Project name"

--- a/charts/pipelines-library/templates/pipelines/java/gradle/gitlab-build-lib-edp.yaml
+++ b/charts/pipelines-library/templates/pipelines/java/gradle/gitlab-build-lib-edp.yaml
@@ -39,6 +39,10 @@ spec:
       description: 'git revision to checkout (branch, tag, sha, ref…)'
       default: "edp"
       type: string
+    - name: targetBranch
+      description: 'Target branch of Merge Request'
+      default: "main"
+      type: string
     - name: CODEBASE_NAME
       default: '{{ $framework }}-maven'
       description: "Project name"

--- a/charts/pipelines-library/templates/pipelines/java/maven/gitlab-build-edp.yaml
+++ b/charts/pipelines-library/templates/pipelines/java/maven/gitlab-build-edp.yaml
@@ -41,6 +41,10 @@ spec:
       description: 'git revision to checkout (branch, tag, sha, ref…)'
       default: "edp"
       type: string
+    - name: targetBranch
+      description: 'Target branch of Merge Request'
+      default: "main"
+      type: string
     - name: CODEBASE_NAME
       default: '{{ $framework }}-maven'
       description: "Project name"

--- a/charts/pipelines-library/templates/pipelines/java/maven/gitlab-build-lib-edp.yaml
+++ b/charts/pipelines-library/templates/pipelines/java/maven/gitlab-build-lib-edp.yaml
@@ -41,6 +41,10 @@ spec:
       description: 'git revision to checkout (branch, tag, sha, ref…)'
       default: "edp"
       type: string
+    - name: targetBranch
+      description: 'Target branch of Merge Request'
+      default: "main"
+      type: string
     - name: CODEBASE_NAME
       default: '{{ $framework }}-maven'
       description: "Project name"

--- a/charts/pipelines-library/templates/pipelines/js/npm/antora/gitlab-build-edp.yaml
+++ b/charts/pipelines-library/templates/pipelines/js/npm/antora/gitlab-build-edp.yaml
@@ -30,6 +30,10 @@ spec:
       description: 'git revision to checkout (branch, tag, sha, ref…)'
       default: "edp"
       type: string
+    - name: targetBranch
+      description: 'Target branch of Merge Request'
+      default: "main"
+      type: string
     - name: CODEBASE_NAME
       default: 'antora-npm-edp-version'
       description: "Project name"

--- a/charts/pipelines-library/templates/pipelines/js/npm/gitlab-build-edp.yaml
+++ b/charts/pipelines-library/templates/pipelines/js/npm/gitlab-build-edp.yaml
@@ -34,6 +34,10 @@ spec:
       description: 'git revision to checkout (branch, tag, sha, ref…)'
       default: "edp"
       type: string
+    - name: targetBranch
+      description: 'Target branch of Merge Request'
+      default: "main"
+      type: string
     - name: CODEBASE_NAME
       default: '{{ $framework }}-npm-edp-version'
       description: "Project name"

--- a/charts/pipelines-library/templates/pipelines/js/npm/gitlab-build-lib-edp.yaml
+++ b/charts/pipelines-library/templates/pipelines/js/npm/gitlab-build-lib-edp.yaml
@@ -34,6 +34,10 @@ spec:
       description: 'git revision to checkout (branch, tag, sha, ref…)'
       default: "edp"
       type: string
+    - name: targetBranch
+      description: 'Target branch of Merge Request'
+      default: "main"
+      type: string
     - name: CODEBASE_NAME
       default: '{{ $framework }}-npm-edp-version'
       description: "Project name"

--- a/charts/pipelines-library/templates/pipelines/js/pnpm/antora/gitlab-build-edp.yaml
+++ b/charts/pipelines-library/templates/pipelines/js/pnpm/antora/gitlab-build-edp.yaml
@@ -30,6 +30,10 @@ spec:
       description: 'git revision to checkout (branch, tag, sha, ref…)'
       default: "edp"
       type: string
+    - name: targetBranch
+      description: 'Target branch of Merge Request'
+      default: "main"
+      type: string
     - name: CODEBASE_NAME
       default: 'antora-pnpm-edp-version'
       description: "Project name"

--- a/charts/pipelines-library/templates/pipelines/js/pnpm/gitlab-build-edp.yaml
+++ b/charts/pipelines-library/templates/pipelines/js/pnpm/gitlab-build-edp.yaml
@@ -34,6 +34,10 @@ spec:
       description: 'git revision to checkout (branch, tag, sha, ref…)'
       default: "edp"
       type: string
+    - name: targetBranch
+      description: 'Target branch of Merge Request'
+      default: "main"
+      type: string
     - name: CODEBASE_NAME
       default: '{{ $framework }}-pnpm-edp-version'
       description: "Project name"

--- a/charts/pipelines-library/templates/pipelines/js/pnpm/gitlab-build-lib-edp.yaml
+++ b/charts/pipelines-library/templates/pipelines/js/pnpm/gitlab-build-lib-edp.yaml
@@ -34,6 +34,10 @@ spec:
       description: 'git revision to checkout (branch, tag, sha, ref…)'
       default: "edp"
       type: string
+    - name: targetBranch
+      description: 'Target branch of Merge Request'
+      default: "main"
+      type: string
     - name: CODEBASE_NAME
       default: '{{ $framework }}-pnpm-edp-version'
       description: "Project name"

--- a/charts/pipelines-library/templates/pipelines/opa/gitlab-build-lib-edp.yaml
+++ b/charts/pipelines-library/templates/pipelines/opa/gitlab-build-lib-edp.yaml
@@ -28,6 +28,10 @@ spec:
       description: 'git revision to checkout (branch, tag, sha, ref…)'
       default: "master"
       type: string
+    - name: targetBranch
+      description: 'Target branch of Merge Request'
+      default: "main"
+      type: string
     - name: CODEBASE_NAME
       default: 'rego-opa'
       description: "Project name"

--- a/charts/pipelines-library/templates/pipelines/python/ansible/gitlab-build-lib-edp.yaml
+++ b/charts/pipelines-library/templates/pipelines/python/ansible/gitlab-build-lib-edp.yaml
@@ -28,6 +28,10 @@ spec:
       description: 'git revision to checkout (branch, tag, sha, ref…)'
       default: "master"
       type: string
+    - name: targetBranch
+      description: 'Target branch of Merge Request'
+      default: "main"
+      type: string
     - name: CODEBASE_NAME
       default: 'ansible'
       description: "Project name"

--- a/charts/pipelines-library/templates/pipelines/python/flask/gitlab-build-edp.yaml
+++ b/charts/pipelines-library/templates/pipelines/python/flask/gitlab-build-edp.yaml
@@ -31,6 +31,10 @@ spec:
       description: 'git revision to checkout (branch, tag, sha, ref…)'
       default: "master"
       type: string
+    - name: targetBranch
+      description: 'Target branch of Merge Request'
+      default: "main"
+      type: string
     - name: CODEBASE_NAME
       default: "python-app"
       description: "Project name"

--- a/charts/pipelines-library/templates/pipelines/python/python3.13/gitlab-build-edp.yaml
+++ b/charts/pipelines-library/templates/pipelines/python/python3.13/gitlab-build-edp.yaml
@@ -28,6 +28,10 @@ spec:
       description: 'git revision to checkout (branch, tag, sha, ref…)'
       default: "master"
       type: string
+    - name: targetBranch
+      description: 'Target branch of Merge Request'
+      default: "main"
+      type: string
     - name: CODEBASE_NAME
       default: "python-app"
       description: "Project name"

--- a/charts/pipelines-library/templates/pipelines/python/python3.13/gitlab-build-lib-edp.yaml
+++ b/charts/pipelines-library/templates/pipelines/python/python3.13/gitlab-build-lib-edp.yaml
@@ -28,6 +28,10 @@ spec:
       description: 'git revision to checkout (branch, tag, sha, ref…)'
       default: "master"
       type: string
+    - name: targetBranch
+      description: 'Target branch of Merge Request'
+      default: "main"
+      type: string
     - name: CODEBASE_NAME
       default: "python-app"
       description: "Project name"

--- a/charts/pipelines-library/templates/pipelines/rpm/maven/gitlab-build-default.yaml
+++ b/charts/pipelines-library/templates/pipelines/rpm/maven/gitlab-build-default.yaml
@@ -34,6 +34,10 @@ spec:
       description: 'git revision to checkout (branch, tag, sha, ref…)'
       default: "edp"
       type: string
+    - name: targetBranch
+      description: 'Target branch of Merge Request'
+      default: "main"
+      type: string
     - name: CODEBASE_NAME
       default: '{{ $framework  }}-maven'
       description: "Project name"

--- a/charts/pipelines-library/templates/pipelines/rpm/maven/gitlab-build-edp.yaml
+++ b/charts/pipelines-library/templates/pipelines/rpm/maven/gitlab-build-edp.yaml
@@ -34,6 +34,10 @@ spec:
       description: 'git revision to checkout (branch, tag, sha, ref…)'
       default: "edp"
       type: string
+    - name: targetBranch
+      description: 'Target branch of Merge Request'
+      default: "main"
+      type: string
     - name: CODEBASE_NAME
       default: '{{ $framework  }}-maven'
       description: "Project name"

--- a/charts/pipelines-library/templates/pipelines/terraform/gitlab-build-lib-edp.yaml
+++ b/charts/pipelines-library/templates/pipelines/terraform/gitlab-build-lib-edp.yaml
@@ -28,6 +28,10 @@ spec:
       description: 'git revision to checkout (branch, tag, sha, ref…)'
       default: "master"
       type: string
+    - name: targetBranch
+      description: 'Target branch of Merge Request'
+      default: "main"
+      type: string
     - name: CODEBASE_NAME
       default: 'terraform-terraform'
       description: "Project name"


### PR DESCRIPTION
## Description
  - Use targetBranch for repository checkout instead of squash-source revision
  - Report pipeline status to actual built commit SHA instead of orphaned commit
  - Ensure init-values receives correct branch parameter for consistency
  - Add runAfter dependency to guarantee SHA availability for status reporting
  - Add targetBranch parameter to all 35 GitLab build pipelines

  This fixes an issue where tags created on squash-merged commits were not
  visible in main branch history, because the webhook's git-source-revision
  (feature branch head) differs from the squash commit SHA placed on the target
  branch. By cloning targetBranch and reporting status on the fetched commit
  SHA, pipeline status and tags now appear on the actual visible commit in
  the target branch history.

Fixes #16665

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Enhancement (non-breaking change which improves an existing feature or documentation)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.

## Checklist:
- [x] I have performed a self-review of my code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Pull Request contains one commit. I squash my commits.

## Screenshots (if appropriate):

## Additional context
Add any other context or screenshots about the feature request here.