### PR TITLE
EPMDEDP-16759: fix: prevent tar file conflict in cache archive

### DIFF
--- a/charts/pipelines-library/templates/tasks/save-cache.yaml
+++ b/charts/pipelines-library/templates/tasks/save-cache.yaml
@@ -47,11 +47,19 @@ spec:
           fi
         fi
 
-        touch ${CACHE_NAME}.tar.zst
+        tar c \
+          -I "zstd -T1 -1" \
+          -f /tmp/${CACHE_NAME}.tar.zst \
+          .
 
-        tar c -I"zstd -T1 -1" --exclude=${CACHE_NAME}.tar.zst -f ${CACHE_NAME}.tar.zst .
-
-        curl -# -L -f -F path=${CACHE_NAME}.tar.zst -X POST -F "file=@${CACHE_NAME}.tar.zst" ${CACHE_SERVER_URL}/upload
+        curl \
+          -# \
+          -L \
+          -f \
+          -F path=${CACHE_NAME}.tar.zst \
+          -X POST \
+          -F "file=@/tmp/${CACHE_NAME}.tar.zst" \
+          ${CACHE_SERVER_URL}/upload
       env:
         - name: CACHE_SERVER_URL
           valueFrom:


### PR DESCRIPTION
  Write the tar archive to /tmp/ instead of the working directory to avoid
  race condition where tar reads a file that's being written to
  simultaneously. This resolves the "file changed as we read it" error that
  occurred when the cache file was partially written while tar was still
  reading from the source directory. The curl command is updated to reference
  the new temporary path for upload.

# Pull Request Template

## Description
Please include a summary of the change and why it is needed.

Fixes #(issue)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Enhancement (non-breaking change which improves an existing feature or documentation)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.

## Checklist:
- [ ] I have performed a self-review of my code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Pull Request contains one commit. I squash my commits.

## Screenshots (if appropriate):

## Additional context
Add any other context or screenshots about the feature request here.