### PR TITLE
EPMDEDP-16790: fix: prevent APPLICATIONS_PAYLOAD from exceeding Tekto…

### DIFF
--- a/charts/pipelines-library/templates/tasks/cd/deploy-applicationset-cli.yaml
+++ b/charts/pipelines-library/templates/tasks/cd/deploy-applicationset-cli.yaml
@@ -78,5 +78,32 @@ spec:
         # TODO: we build our custom argocd-cli that has fixed issue with argocd app wait
         argocd app wait -l $selector --health --sync
 
-        printf "%s" "${new_tags}" > "$(results.APPLICATIONS_PAYLOAD.path)"
+        # Tekton termination message limit is 4096 bytes, but the actual result content budget is lower:
+        # Tekton JSON-encodes the value (each " becomes \", ~8% overhead) and prepends internal entries
+        # (e.g. ExitCode) plus the result key/type wrapper — consuming ~600 bytes of the 4096 budget.
+        result_size_limit=3500
+
+        display_result=$(printf '%s' "${new_tags}" | jq -c --argjson limit "${result_size_limit}" '
+          to_entries | reduce .[] as $entry (
+            {r: {}, done: false};
+            if .done then .
+            else
+              (.r + {($entry.key): $entry.value}) as $cand |
+              if ($cand | tojson | length) <= $limit
+              then {r: $cand, done: false}
+              else {r: .r, done: true}
+              end
+            end
+          ) | .r
+        ')
+
+        total_apps=$(printf '%s' "${new_tags}" | jq 'keys | length')
+        display_apps=$(printf '%s' "${display_result}" | jq 'keys | length')
+        display_size=${#display_result}
+        echo "APPLICATIONS_PAYLOAD result: ${display_apps}/${total_apps} apps, ${display_size} bytes (limit ${result_size_limit})"
+        if [ "${display_apps}" -lt "${total_apps}" ]; then
+          echo "WARNING: ${total_apps} apps exceed result size limit — only first ${display_apps} apps shown in portal"
+        fi
+
+        printf '%s' "${display_result}" > "$(results.APPLICATIONS_PAYLOAD.path)"
 {{ end }}


### PR DESCRIPTION
…n result size limit

  Implement size-aware truncation of deployment results to fit within Tekton's
  4096-byte termination message limit. Uses jq to progressively include
  applications until the 3500-byte content limit is reached, accounting for
  JSON encoding overhead (~8%) and Tekton's internal metadata (~600 bytes).

  Logs warnings when applications are truncated, ensuring users are aware
  that the portal may display fewer apps than were actually deployed.

# Pull Request Template

## Description
Please include a summary of the change and why it is needed.

Fixes #(issue)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Enhancement (non-breaking change which improves an existing feature or documentation)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.

## Checklist:
- [ ] I have performed a self-review of my code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Pull Request contains one commit. I squash my commits.

## Screenshots (if appropriate):

## Additional context
Add any other context or screenshots about the feature request here.